### PR TITLE
Php 7.4.32 initial patch with scripts for reproducible build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Ignore everything in this directory
-*
+build/**
+wasmlabs-build-output/**
 # Except this file
 !.gitignore

--- a/libs/sqlite/README.md
+++ b/libs/sqlite/README.md
@@ -1,0 +1,7 @@
+# About
+
+Build scripts and patches for the sqlite3 library.
+
+# References
+
+The patch and approach have been greatly influenced by the changes in [rcarmo/wasi-sqlite](https://github.com/rcarmo/wasi-sqlite)

--- a/libs/sqlite/version-3.39.2/build.sh
+++ b/libs/sqlite/version-3.39.2/build.sh
@@ -5,12 +5,12 @@ then
 fi
 export WASI_SDK_ROOT=$(readlink -f $WASI_SDK_ROOT)
 
-if [[ ! -v WASMLABS_BUILD_ROOT ]]
+if [[ ! -v WASMLABS_BUILD_OUTPUT ]]
 then
-    echo "Please set WASMLABS_BUILD_ROOT and run again. Artifacts will go to \$WASMLABS_BUILD_ROOT/{include/lib/share}"
+    echo "Please set WASMLABS_BUILD_OUTPUT and run again. Artifacts will go to \$WASMLABS_BUILD_OUTPUT/{bin/include/lib/share}"
     exit 1
 fi
-export WASMLABS_BUILD_ROOT=$(readlink -f $WASMLABS_BUILD_ROOT)
+export WASMLABS_BUILD_OUTPUT=$(readlink -f $WASMLABS_BUILD_OUTPUT)
 
 PATCH_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/patch.v1.diff
 if [[ ! -f $PATCH_PATH ]]
@@ -19,12 +19,15 @@ then
     exit 1
 fi
 
-pushd $WASMLABS_BUILD_ROOT
+pushd $WASMLABS_BUILD_OUTPUT
 function onExit {
     popd
 }
 trap onExit EXIT
 
-git clone --depth=1 -b version-3.39.2 https://github.com/sqlite/sqlite.git sqlite-3.39.2-build && cd sqlite-3.39.2-build
+mkdir build 2>/dev/null
+cd build
+
+git clone --depth=1 -b version-3.39.2 https://github.com/sqlite/sqlite.git sqlite-build-version-3.39.2 && cd sqlite-build-version-3.39.2
 git apply $PATCH_PATH
 ./wasmlabs-build.sh

--- a/libs/sqlite/version-3.39.2/build.sh
+++ b/libs/sqlite/version-3.39.2/build.sh
@@ -1,0 +1,30 @@
+if [[ ! -v WASI_SDK_ROOT ]]
+then
+    echo "Please set WASI_SDK_ROOT and run again"
+    exit 1
+fi
+export WASI_SDK_ROOT=$(readlink -f $WASI_SDK_ROOT)
+
+if [[ ! -v WASMLABS_BUILD_ROOT ]]
+then
+    echo "Please set WASMLABS_BUILD_ROOT and run again. Artifacts will go to \$WASMLABS_BUILD_ROOT/{include/lib/share}"
+    exit 1
+fi
+export WASMLABS_BUILD_ROOT=$(readlink -f $WASMLABS_BUILD_ROOT)
+
+PATCH_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/patch.v1.diff
+if [[ ! -f $PATCH_PATH ]]
+then
+    echo "Cannod find the patch file in $PATCH_PATH"
+    exit 1
+fi
+
+pushd $WASMLABS_BUILD_ROOT
+function onExit {
+    popd
+}
+trap onExit EXIT
+
+git clone --depth=1 -b version-3.39.2 https://github.com/sqlite/sqlite.git sqlite-3.39.2-build && cd sqlite-3.39.2-build
+git apply $PATCH_PATH
+./wasmlabs-build.sh

--- a/libs/sqlite/version-3.39.2/patch.v1.diff
+++ b/libs/sqlite/version-3.39.2/patch.v1.diff
@@ -1,0 +1,141 @@
+diff --git a/src/os_unix.c b/src/os_unix.c
+index b933de376..79005a87d 100644
+--- a/src/os_unix.c
++++ b/src/os_unix.c
+@@ -457,7 +457,11 @@ static struct unix_syscall {
+ #define osPwrite64  ((ssize_t(*)(int,const void*,size_t,off64_t))\
+                     aSyscall[13].pCurrent)
+ 
++#if !defined(WASM_WASI)
+   { "fchmod",       (sqlite3_syscall_ptr)fchmod,          0  },
++#else
++  { "fchmod",       (sqlite3_syscall_ptr)0,          0  },
++#endif
+ #define osFchmod    ((int(*)(int,mode_t))aSyscall[14].pCurrent)
+ 
+ #if defined(HAVE_POSIX_FALLOCATE) && HAVE_POSIX_FALLOCATE
+@@ -479,14 +483,14 @@ static struct unix_syscall {
+   { "rmdir",        (sqlite3_syscall_ptr)rmdir,           0 },
+ #define osRmdir     ((int(*)(const char*))aSyscall[19].pCurrent)
+ 
+-#if defined(HAVE_FCHOWN)
++#if defined(HAVE_FCHOWN) && !defined(WASM_WASI)
+   { "fchown",       (sqlite3_syscall_ptr)fchown,          0 },
+ #else
+   { "fchown",       (sqlite3_syscall_ptr)0,               0 },
+ #endif
+ #define osFchown    ((int(*)(int,uid_t,gid_t))aSyscall[20].pCurrent)
+ 
+-#if defined(HAVE_FCHOWN)
++#if defined(HAVE_FCHOWN) && !defined(WASM_WASI)
+   { "geteuid",      (sqlite3_syscall_ptr)geteuid,         0 },
+ #else
+   { "geteuid",      (sqlite3_syscall_ptr)0,               0 },
+@@ -8020,6 +8024,8 @@ int sqlite3_os_init(void){
+     UNIXVFS("unix",          autolockIoFinder ),
+ #elif OS_VXWORKS
+     UNIXVFS("unix",          vxworksIoFinder ),
++#elif WASM_WASI
++    UNIXVFS("unix",          dotlockIoFinder ),
+ #else
+     UNIXVFS("unix",          posixIoFinder ),
+ #endif
+diff --git a/wasmlabs-build.sh b/wasmlabs-build.sh
+new file mode 100755
+index 000000000..10485f5b1
+--- /dev/null
++++ b/wasmlabs-build.sh
+@@ -0,0 +1,67 @@
++#!/bin/bash
++
++if [[ ! -v WASI_SDK_ROOT ]]
++then
++    echo "Please set WASI_SDK_ROOT and run again"
++    exit 1
++fi
++
++if [[ ! -v WASMLABS_BUILD_ROOT ]]
++then
++    echo "Assuming $PWD/wasmlabs-output as WASMLABS_BUILD_ROOT"
++    export WASMLABS_BUILD_ROOT=$PWD/wasmlabs-output
++fi
++
++function onExit {
++    echo "=============================================================="
++    echo "Build progress logs:"
++    cat wasmlabs-progress.log
++}
++trap onExit EXIT
++
++echo "$(date --iso-8601=ns) | Using WASI_SDK_ROOT=$WASI_SDK_ROOT " > wasmlabs-progress.log
++
++function logStatus {
++    echo "$(date --iso-8601=ns) | $@" >> wasmlabs-progress.log
++}
++
++export WASI_SYSROOT="${WASI_SDK_ROOT}/share/wasi-sysroot"
++
++export CC=${WASI_SDK_ROOT}/bin/clang
++export LD=${WASI_SDK_ROOT}/bin/wasm-ld
++export CXX=${WASI_SDK_ROOT}/bin/clang++
++export NM=${WASI_SDK_ROOT}/bin/llvm-nm  
++export AR=${WASI_SDK_ROOT}/bin/llvm-ar
++export RANLIB=${WASI_SDK_ROOT}/bin/llvm-ranlib
++
++export CFLAGS_CONFIG="-O2"
++
++export CFLAGS_WASI="--sysroot=${WASI_SYSROOT} -I./wasmlabs-stubs -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS"
++export LDFLAGS_WASI="--sysroot=${WASI_SYSROOT} -lwasi-emulated-mman -lwasi-emulated-getpid -lwasi-emulated-signal -lwasi-emulated-process-clocks"
++
++export CFLAGS_SQLITE='-DSQLITE_OMIT_WAL=1 -DSQLITE_DEFAULT_SYNCHRONOUS=0 -DSQLITE_OMIT_RANDOMNESS  -DLONGDOUBLE_TYPE=double -DSQLITE_BYTEORDER=1234 -DNDEBUG=1 -DSQLITE_OS_UNIX=1 -DSQLITE_DISABLE_LFS=1 -DSQLITE_ENABLE_JSON1=1 -DSQLITE_HAVE_ISNAN=1 -DSQLITE_HAVE_MALLOC_USABLE_SIZE=1 -DSQLITE_HAVE_STRCHRNUL=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1 -DSQLITE_OMIT_DEPRECATED=1 -DSQLITE_OMIT_LOAD_EXTENSION=1 -DSQLITE_TEMP_STORE=2 -DSQLITE_THREADSAFE=0 -DSQLITE_USE_URI=1 -DSQLITE_ENABLE_RTREE=1 -DSQLITE_ENABLE_FTS5=1 -DSQLITE_HAVE_USLEEP=1 -DSQLITE_ENABLE_EXPLAIN_COMMENTS=1'
++
++logStatus "Using SQLITE DEFINES: $CFLAGS_SQLITE"
++
++export SQLITE_CONFIGURE=' --disable-threadsafe --enable-tempstore=yes'
++
++export CFLAGS_BUILD='-D_POSIX_SOURCE=1 -D_GNU_SOURCE=1 -DHAVE_FORK=0 -DWASM_WASI'
++
++# We need to add LDFLAGS ot CFLAGS because autoconf compiles(+links) to binary when checking stuff
++export CFLAGS="$CFLAGS_CONFIG $CFLAGS_WASI $CFLAGS_SQLITE $CFLAGS_BUILD $LDFLAGS_WASI"
++export LDFLAGS="$LDFLAGS_WASI"
++
++logStatus "Configuring build with '$SQLITE_CONFIGURE'... "
++./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi $SQLITE_CONFIGURE
++
++logStatus "Building... "
++make libsqlite3.la
++
++logStatus "Preparing artifacts... "
++mkdir -p $WASMLABS_BUILD_ROOT/include 2>/dev/null
++mkdir -p $WASMLABS_BUILD_ROOT/lib 2>/dev/null
++
++cp sqlite3.h sqlite3ext.h sqlite3session.h $WASMLABS_BUILD_ROOT/include/
++cp .libs/libsqlite3.a $WASMLABS_BUILD_ROOT/lib/
++
++logStatus "DONE. Artifacts in $WASMLABS_BUILD_ROOT"
+diff --git a/wasmlabs-stubs/fcntl.h b/wasmlabs-stubs/fcntl.h
+new file mode 100644
+index 000000000..c0f8abb71
+--- /dev/null
++++ b/wasmlabs-stubs/fcntl.h
+@@ -0,0 +1,20 @@
++#pragma once
++
++#include_next<fcntl.h>
++
++#ifdef WASM_WASI
++
++#define F_RDLCK 0
++#define F_WRLCK 1
++#define F_UNLCK 2
++#if __LONG_MAX == 0x7fffffffL
++#define F_GETLK 12
++#define F_SETLK 13
++#define F_SETLKW 14
++#else
++#define F_GETLK 5
++#define F_SETLK 6
++#define F_SETLKW 7
++#endif
++
++#endif //WASM_WASI

--- a/libs/sqlite/version-3.39.2/patch.v1.diff
+++ b/libs/sqlite/version-3.39.2/patch.v1.diff
@@ -42,7 +42,7 @@ index b933de376..79005a87d 100644
  #endif
 diff --git a/wasmlabs-build.sh b/wasmlabs-build.sh
 new file mode 100755
-index 000000000..10485f5b1
+index 000000000..4ff60ec8c
 --- /dev/null
 +++ b/wasmlabs-build.sh
 @@ -0,0 +1,67 @@
@@ -54,10 +54,10 @@ index 000000000..10485f5b1
 +    exit 1
 +fi
 +
-+if [[ ! -v WASMLABS_BUILD_ROOT ]]
++if [[ ! -v WASMLABS_BUILD_OUTPUT ]]
 +then
-+    echo "Assuming $PWD/wasmlabs-output as WASMLABS_BUILD_ROOT"
-+    export WASMLABS_BUILD_ROOT=$PWD/wasmlabs-output
++    echo "Assuming $PWD/wasmlabs-build-output as WASMLABS_BUILD_OUTPUT"
++    export WASMLABS_BUILD_OUTPUT=$PWD/wasmlabs-build-output
 +fi
 +
 +function onExit {
@@ -78,7 +78,7 @@ index 000000000..10485f5b1
 +export CC=${WASI_SDK_ROOT}/bin/clang
 +export LD=${WASI_SDK_ROOT}/bin/wasm-ld
 +export CXX=${WASI_SDK_ROOT}/bin/clang++
-+export NM=${WASI_SDK_ROOT}/bin/llvm-nm  
++export NM=${WASI_SDK_ROOT}/bin/llvm-nm
 +export AR=${WASI_SDK_ROOT}/bin/llvm-ar
 +export RANLIB=${WASI_SDK_ROOT}/bin/llvm-ranlib
 +
@@ -106,13 +106,13 @@ index 000000000..10485f5b1
 +make libsqlite3.la
 +
 +logStatus "Preparing artifacts... "
-+mkdir -p $WASMLABS_BUILD_ROOT/include 2>/dev/null
-+mkdir -p $WASMLABS_BUILD_ROOT/lib 2>/dev/null
++mkdir -p $WASMLABS_BUILD_OUTPUT/include 2>/dev/null
++mkdir -p $WASMLABS_BUILD_OUTPUT/lib 2>/dev/null
 +
-+cp sqlite3.h sqlite3ext.h sqlite3session.h $WASMLABS_BUILD_ROOT/include/
-+cp .libs/libsqlite3.a $WASMLABS_BUILD_ROOT/lib/
++cp sqlite3.h sqlite3ext.h sqlite3session.h $WASMLABS_BUILD_OUTPUT/include/
++cp .libs/libsqlite3.a $WASMLABS_BUILD_OUTPUT/lib/
 +
-+logStatus "DONE. Artifacts in $WASMLABS_BUILD_ROOT"
++logStatus "DONE. Artifacts in $WASMLABS_BUILD_OUTPUT"
 diff --git a/wasmlabs-stubs/fcntl.h b/wasmlabs-stubs/fcntl.h
 new file mode 100644
 index 000000000..c0f8abb71

--- a/php/README.md
+++ b/php/README.md
@@ -6,38 +6,36 @@ Basic instructions on how to build different php versions.
 
 All build operations rely on WASISDK. You would need to download and install it.
 
-# 7.3.33 - patch-v2.diff
+The php build uses autoconf and make.
 
-Assuming we are working from the current directory of this README.
+Define WASI_SDK_ROOT to point to a local installation of WasiSDK and WASMLABS_BUILD_OUTPUT to point to your working folder
+
+# 7.3.33 - patch.v2.diff
 
 This is work in progress and we're currently building only php-cgi.
 
 **Note**: A build with this patch has some issues interpreting WP. We are working on it. 
 
-1. Clone the 7.3.33 tag into a working folder
+1. To build just run `php/patches/7.3.33/build.sh`
 
-```bash
-git clone --depth=1 -b php-7.3.33 https://github.com/php/php-src.git php-7.3.33-build && cd php-7.3.33-build
-```
+2. You can find `php-cgi` in `$WASMLABS_BUILD_OUTPUT/bin/php-cgi`
 
-2. Apply the patch inside that folder
+# 7.4.32 - patch.v1.diff
 
-```bash
-git apply ../patches/patch-v2.diff
-```
+This is work in progress and we're currently building only php-cgi.
 
-3. Set the location to WASI SDK and run the build script 
-```bash
-export WASI_SDK_ROOT=/path/to/wasi-sdk-16.0
-./wasmlabs-build.sh
-```
+This build also downloads and builds sqlite3(3.39.2) and links it into the php binary
 
-4. You can find `php-cgi` in `sapi/cgi/php-cgi`
+**Note**: A build with this patch has some issues interpreting WP. We are working on it. 
 
-## Running a script with php-cgi
+1. To build just run `php/patches/7.4.32/build.sh`
+
+2. You can find `php-cgi` in `$WASMLABS_BUILD_OUTPUT/bin/php-cgi`
+
+# Running a script with php-cgi
 
 Don't forget to map the folder that contains the php script, which you want to run. For example:
 
 ```bash
-wasmtime --mapdir=./::./ -- sapi/cgi/php-cgi ./Zend/bench.php
+wasmtime --mapdir=./::./ -- php-cgi my-script.php
 ```

--- a/php/patches/7.3.33/build.sh
+++ b/php/patches/7.3.33/build.sh
@@ -1,0 +1,35 @@
+if [[ ! -v WASI_SDK_ROOT ]]
+then
+    echo "Please set WASI_SDK_ROOT and run again"
+    exit 1
+fi
+export WASI_SDK_ROOT=$(readlink -f $WASI_SDK_ROOT)
+
+if [[ ! -v WASMLABS_BUILD_OUTPUT ]]
+then
+    echo "Please set WASMLABS_BUILD_OUTPUT and run again. Artifacts will go to \$WASMLABS_BUILD_OUTPUT/{include/lib/share}"
+    exit 1
+fi
+export WASMLABS_BUILD_OUTPUT=$(readlink -f $WASMLABS_BUILD_OUTPUT)
+
+THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PATCH_PATH=$THIS_SCRIPT_DIR/patch.v2.diff
+if [[ ! -f $PATCH_PATH ]]
+then
+    echo "Cannot find the patch file in $PATCH_PATH"
+    exit 1
+fi
+
+pushd $WASMLABS_BUILD_OUTPUT
+function onExit {
+    popd
+}
+trap onExit EXIT
+
+mkdir build 2>/dev-null
+cd build
+
+#REPO-build-TAG
+git clone --depth=1 -b php-7.4.32 https://github.com/php/php-src.git php-src-build-php-7.4.32 && cd php-src-build-php-7.4.32
+git apply $PATCH_PATH
+./wasmlabs-build.sh

--- a/php/patches/7.3.33/build.sh
+++ b/php/patches/7.3.33/build.sh
@@ -26,10 +26,10 @@ function onExit {
 }
 trap onExit EXIT
 
-mkdir build 2>/dev-null
+mkdir build 2>/dev/null
 cd build
 
 #REPO-build-TAG
-git clone --depth=1 -b php-7.4.32 https://github.com/php/php-src.git php-src-build-php-7.4.32 && cd php-src-build-php-7.4.32
+git clone --depth=1 -b php-7.3.32 https://github.com/php/php-src.git php-src-build-php-7.3.33 && cd php-src-build-php-7.3.33
 git apply $PATCH_PATH
 ./wasmlabs-build.sh

--- a/php/patches/7.3.33/wasmlabs-README.md
+++ b/php/patches/7.3.33/wasmlabs-README.md
@@ -1,0 +1,85 @@
+# About
+
+This contains a non-exhaustive list of changes that we had to make to be able to build the PHP codebase for wasm32-wasi.
+
+To remove or add code for wasm32-wasi builds we are using the 'WASM_WASI' macro.
+
+# emulated functionality
+
+We are using emulation of getpid, signals and clocks.
+
+We are not using mman emulation due to the reasons outlined [below](#mmap-support).
+
+# excluded code
+
+This describes the most common places where we needed to exclude code because
+a method or constant is not available or is somehow different with WASI.
+
+## S_IFSOCK is the same as  S_IFFIFO
+
+WASI snapshot2 is not out yet - https://github.com/nodejs/uvwasi/issues/59.
+
+Thus there is no support for a FIFO filetype. So the two constants were
+defined to the same value. Because of this a switch/case on file type will fail
+due to duplicate case labels.
+
+We've commented out the S_IFFIFO cases.
+
+## setjmp and longjmp
+
+There is no such support in WASI yet.
+
+We have taken a shortcut and just botched the exception handling in the zend
+zend engine. The program will just ignore exceptions as they happen.
+
+## sqlite3 support
+
+We are using sqlite 3.39.2 instead of the original 3.28.0 that goes with php 7.3.33.
+
+Additionally sqlite3 had to be modified in some ways for WASM_WASI builds:
+
+ - mark fchmod, fchown as not defined
+ - use "dotlockIoFinder" for file locking
+ - skip sqlite3_finalize
+
+## unsupported posix methods
+
+We have stubbed the posix methods in `ext/posix/posix.c` which are not supported for WASI.
+
+Other methods, which are direcly used without wrapping were skipped in place by stubbing
+the method that is calling them.
+
+## php flock
+
+File locking is also stubbed and always returns success.
+
+## mmap support
+
+**TL;DR:** 
+
+We are building without MMAP support. To make it work, changes had to be made to zend_alloc.c resulting in a slower but correct behavior.
+
+
+**Details:** 
+
+Take a look [here](https://linux.die.net/man/2/mmap) for the docs for mmap and munmap
+
+The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-16 tag).
+
+ - mmap uses malloc to reserve the necessary amount of memory (always ignoring the addr hint)
+ - mmap zeroes out bytes if MAP_ANONYMOUS is used
+ - mmap reads file contents if mapping an fd
+ - munmap only supports unmapping of the exact same chunk (addr + size) that was previously mapped - as it is effectively a free of the malloc-ed memory
+
+In the php code there are two places where mman.h is used
+
+1. In zend_alloc.c - for custom memory allocation
+
+ - there is code that relies on partial munmap (for the sake of proper alignment at higher level). Using the emulated mmap will lead to leaks here, as munmap fails.
+ - there is code that relies on the capability to extend a mmaped chunk - this will fail and lead to performance degradation (falling-back to reallocation)
+
+2. In plain_wrapper.c and zend_stream.c - for reading of the interpreted .php source files
+
+ - the tricky thing here is the ZEND_MMAP_AHEAD needed by the zend_language_scanner. The language parser depends on having a bunch of null-terminating characters at the end of the interpreted string. The usual mmap behavior guarantees that when files are mmaped memory is reserved in pages of size `sysconf(_SC_PAGE_SIZE)`, which is padded with `\0`-s after the file contents. However, the emulated mmap does not do that (as it only malloc-s what was requested). This leads to the parser reading random stuff from memory after the mmaped file contents. 
+
+

--- a/php/patches/7.4.32/build.sh
+++ b/php/patches/7.4.32/build.sh
@@ -1,0 +1,39 @@
+if [[ ! -v WASI_SDK_ROOT ]]
+then
+    echo "Please set WASI_SDK_ROOT and run again"
+    exit 1
+fi
+export WASI_SDK_ROOT=$(readlink -f $WASI_SDK_ROOT)
+
+if [[ ! -v WASMLABS_BUILD_OUTPUT ]]
+then
+    echo "Please set WASMLABS_BUILD_OUTPUT and run again. Artifacts will go to \$WASMLABS_BUILD_OUTPUT/{include/lib/share}"
+    exit 1
+fi
+export WASMLABS_BUILD_OUTPUT=$(readlink -f $WASMLABS_BUILD_OUTPUT)
+
+THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PATCH_PATH=$THIS_SCRIPT_DIR/patch.v1.diff
+if [[ ! -f $PATCH_PATH ]]
+then
+    echo "Cannot find the patch file in $PATCH_PATH"
+    exit 1
+fi
+
+SQLITE_BUILD_PATH=$THIS_SCRIPT_DIR/../../../libs/sqlite/version-3.39.2/build.sh
+
+pushd $WASMLABS_BUILD_OUTPUT
+function onExit {
+    popd
+}
+trap onExit EXIT
+
+$SQLITE_BUILD_PATH
+
+mkdir build 2>/dev/null
+cd build
+
+#REPO-build-TAG
+git clone --depth=1 -b php-7.4.32 https://github.com/php/php-src.git php-src-build-php-7.4.32 && cd php-src-build-php-7.4.32
+git apply $PATCH_PATH
+./wasmlabs-build.sh

--- a/php/patches/7.4.32/patch.v1.diff
+++ b/php/patches/7.4.32/patch.v1.diff
@@ -1,0 +1,2029 @@
+diff --git a/Zend/zend.c b/Zend/zend.c
+index b667514020..bf72cce272 100644
+--- a/Zend/zend.c
++++ b/Zend/zend.c
+@@ -709,7 +709,9 @@ static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{
+ #endif
+ 	executor_globals->saved_fpu_cw_ptr = NULL;
+ 	executor_globals->active = 0;
++#ifndef WASM_WASI
+ 	executor_globals->bailout = NULL;
++#endif
+ 	executor_globals->error_handling  = EH_NORMAL;
+ 	executor_globals->exception_class = NULL;
+ 	executor_globals->exception = NULL;
+@@ -1120,6 +1122,7 @@ BEGIN_EXTERN_C()
+ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32_t lineno) /* {{{ */
+ {
+ 
++#ifndef WASM_WASI
+ 	if (!EG(bailout)) {
+ 		zend_output_debug_string(1, "%s(%d) : Bailed out without a bailout address!", filename, lineno);
+ 		exit(-1);
+@@ -1130,6 +1133,7 @@ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32
+ 	CG(in_compilation) = 0;
+ 	EG(current_execute_data) = NULL;
+ 	LONGJMP(*EG(bailout), FAILURE);
++#endif
+ }
+ /* }}} */
+ END_EXTERN_C()
+diff --git a/Zend/zend.h b/Zend/zend.h
+index 94fd9a3559..75bea56935 100644
+--- a/Zend/zend.h
++++ b/Zend/zend.h
+@@ -209,6 +209,7 @@ typedef int (*zend_write_func_t)(const char *str, size_t str_length);
+ 
+ #define zend_bailout()		_zend_bailout(__FILE__, __LINE__)
+ 
++#ifndef WASM_WASI
+ #define zend_try												\
+ 	{															\
+ 		JMP_BUF *__orig_bailout = EG(bailout);					\
+@@ -225,6 +226,18 @@ typedef int (*zend_write_func_t)(const char *str, size_t str_length);
+ 	}
+ #define zend_first_try		EG(bailout)=NULL;	zend_try
+ 
++#else // WASM_WASI
++#define zend_try												\
++	{															\
++		if (1) {
++#define zend_catch												\
++		} else {
++#define zend_end_try()											\
++		}														\
++	}
++#define zend_first_try		zend_try
++#endif // WASM_WASI
++
+ BEGIN_EXTERN_C()
+ int zend_startup(zend_utility_functions *utility_functions);
+ void zend_shutdown(void);
+diff --git a/Zend/zend_alloc.c b/Zend/zend_alloc.c
+index 3a33e5441c..46e97a30fa 100644
+--- a/Zend/zend_alloc.c
++++ b/Zend/zend_alloc.c
+@@ -670,7 +670,9 @@ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
+ 	} else if (ZEND_MM_ALIGNED_OFFSET(ptr, alignment) == 0) {
+ #ifdef MADV_HUGEPAGE
+ 		if (zend_mm_use_huge_pages) {
++#ifndef WASM_WASI
+ 			madvise(ptr, size, MADV_HUGEPAGE);
++#endif // WASM_WASI
+ 		}
+ #endif
+ 		return ptr;
+@@ -703,7 +705,9 @@ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
+ 		}
+ # ifdef MADV_HUGEPAGE
+ 		if (zend_mm_use_huge_pages) {
++#ifndef WASM_WASI
+ 			madvise(ptr, size, MADV_HUGEPAGE);
++#endif // WASM_WASI
+ 		}
+ # endif
+ #endif
+diff --git a/Zend/zend_globals.h b/Zend/zend_globals.h
+index 2e9fff40ad..e95771ef42 100644
+--- a/Zend/zend_globals.h
++++ b/Zend/zend_globals.h
+@@ -21,7 +21,9 @@
+ #define ZEND_GLOBALS_H
+ 
+ 
++#ifndef WASM_WASI
+ #include <setjmp.h>
++#endif
+ 
+ #include "zend_globals_macros.h"
+ 
+@@ -147,7 +149,9 @@ struct _zend_executor_globals {
+ 
+ 	HashTable included_files;	/* files already included */
+ 
++#ifndef WASM_WASI
+ 	JMP_BUF *bailout;
++#endif
+ 
+ 	int error_reporting;
+ 	int exit_status;
+diff --git a/Zend/zend_types.h b/Zend/zend_types.h
+index 7b8c079c45..e4759b5fbb 100644
+--- a/Zend/zend_types.h
++++ b/Zend/zend_types.h
+@@ -1280,4 +1280,16 @@ static zend_always_inline uint32_t zval_delref_p(zval* pz) {
+ 	do { ZVAL_COPY_OR_DUP(z, v); Z_PROP_FLAG_P(z) = Z_PROP_FLAG_P(v); } while (0)
+ 
+ 
++#ifdef WASM_WASI
++
++#define	LOG_EMERG	0	/* system is unusable */
++#define	LOG_ALERT	1	/* action must be taken immediately */
++#define	LOG_CRIT	2	/* critical conditions */
++#define	LOG_ERR		3	/* error conditions */
++#define	LOG_WARNING	4	/* warning conditions */
++#define	LOG_NOTICE	5	/* normal but significant condition */
++#define	LOG_INFO	6	/* informational */
++#define	LOG_DEBUG	7	/* debug-level messages */
++
++#endif // WASM_WASI
+ #endif /* ZEND_TYPES_H */
+diff --git a/Zend/zend_virtual_cwd.c b/Zend/zend_virtual_cwd.c
+index e16ba50f13..c3bcf5a7bc 100644
+--- a/Zend/zend_virtual_cwd.c
++++ b/Zend/zend_virtual_cwd.c
+@@ -1396,7 +1396,11 @@ CWD_API int virtual_chmod(const char *filename, mode_t mode) /* {{{ */
+ 		ret = php_win32_ioutil_chmod(new_state.cwd, mode);
+ 	}
+ #else
++#ifndef WASM_WASI
+ 	ret = chmod(new_state.cwd, mode);
++#else
++	ret = 0;
++#endif // WASM_WASI
+ #endif
+ 
+ 	CWD_STATE_FREE_ERR(&new_state);
+@@ -1423,7 +1427,11 @@ CWD_API int virtual_chown(const char *filename, uid_t owner, gid_t group, int li
+ 		ret = -1;
+ #endif
+ 	} else {
++#ifndef WASM_WASI
+ 		ret = chown(new_state.cwd, owner, group);
++#else
++		ret = 0;
++#endif // WASM_WASI
+ 	}
+ 
+ 	CWD_STATE_FREE_ERR(&new_state);
+@@ -1701,7 +1709,11 @@ CWD_API FILE *virtual_popen(const char *command, const char *type) /* {{{ */
+ 	*ptr++ = ' ';
+ 
+ 	memcpy(ptr, command, command_length+1);
++#ifndef WASM_WASI
+ 	retval = popen(command_line, type);
++#else
++	retval = 0;
++#endif // WASM_WASI
+ 
+ 	efree(command_line);
+ 	return retval;
+diff --git a/Zend/zend_vm_execute.h b/Zend/zend_vm_execute.h
+index 2875fd3740..230854642b 100644
+--- a/Zend/zend_vm_execute.h
++++ b/Zend/zend_vm_execute.h
+@@ -2378,7 +2378,11 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_EXIT_SPEC_HANDLER
+ 		} while (0);
+ 		FREE_OP(free_op1);
+ 	}
++#ifndef WASM_WASI
+ 	zend_bailout();
++#else
++	exit(0);
++#endif // WASM_WASI
+ 	ZEND_VM_NEXT_OPCODE(); /* Never reached */
+ }
+ 
+diff --git a/ext/fileinfo/libmagic/compress.c b/ext/fileinfo/libmagic/compress.c
+index e2a2b8ff9c..c5c4bc39f1 100644
+--- a/ext/fileinfo/libmagic/compress.c
++++ b/ext/fileinfo/libmagic/compress.c
+@@ -423,7 +423,7 @@ file_pipe2file(struct magic_set *ms, int fd, const void *startbuf,
+ 	int tfd;
+ 
+ 	(void)strlcpy(buf, "/tmp/file.XXXXXX", sizeof buf);
+-#ifndef HAVE_MKSTEMP
++#if !defined(HAVE_MKSTEMP) && !defined(WASM_WASI)
+ 	{
+ 		char *ptr = mktemp(buf);
+ 		tfd = open(ptr, O_RDWR|O_TRUNC|O_EXCL|O_CREAT, 0600);
+diff --git a/ext/fileinfo/libmagic/fsmagic.c b/ext/fileinfo/libmagic/fsmagic.c
+index 938b526a37..4335b5b0da 100644
+--- a/ext/fileinfo/libmagic/fsmagic.c
++++ b/ext/fileinfo/libmagic/fsmagic.c
+@@ -199,6 +199,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, zend_stat_t *sb)
+ 	return 1;
+ #endif
+ 
++#ifndef WASM_WASI
+ #ifdef	S_IFSOCK
+ #ifndef __COHERENT__
+ 	case S_IFSOCK:
+@@ -211,6 +212,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, zend_stat_t *sb)
+ 		break;
+ #endif
+ #endif
++#endif // WASM_WASI
+ 	case S_IFREG:
+ 		/*
+ 		 * regular file, check next possibility
+diff --git a/ext/pdo_sqlite/sqlite_statement.c b/ext/pdo_sqlite/sqlite_statement.c
+index a8723da640..ae48e3be3d 100644
+--- a/ext/pdo_sqlite/sqlite_statement.c
++++ b/ext/pdo_sqlite/sqlite_statement.c
+@@ -34,7 +34,9 @@ static int pdo_sqlite_stmt_dtor(pdo_stmt_t *stmt)
+ 	pdo_sqlite_stmt *S = (pdo_sqlite_stmt*)stmt->driver_data;
+ 
+ 	if (S->stmt) {
++#ifndef WASM_WASI
+ 		sqlite3_finalize(S->stmt);
++#endif
+ 		S->stmt = NULL;
+ 	}
+ 	efree(S);
+diff --git a/ext/posix/posix.c b/ext/posix/posix.c
+index 31d3feed8d..ad90e205ac 100644
+--- a/ext/posix/posix.c
++++ b/ext/posix/posix.c
+@@ -40,8 +40,10 @@
+ #include <signal.h>
+ #include <sys/times.h>
+ #include <errno.h>
++#ifndef WASM_WASI
+ #include <grp.h>
+ #include <pwd.h>
++#endif // WASM_WASI
+ #if HAVE_SYS_MKDEV_H
+ # include <sys/mkdev.h>
+ #endif
+@@ -458,6 +460,7 @@ ZEND_GET_MODULE(posix)
+ 
+ PHP_FUNCTION(posix_kill)
+ {
++#ifndef WASM_WASI
+ 	zend_long pid, sig;
+ 
+ 	ZEND_PARSE_PARAMETERS_START(2, 2)
+@@ -469,6 +472,7 @@ PHP_FUNCTION(posix_kill)
+ 		POSIX_G(last_error) = errno;
+ 		RETURN_FALSE;
+   	}
++#endif // WASM_WASI
+ 
+ 	RETURN_TRUE;
+ }
+@@ -478,7 +482,11 @@ PHP_FUNCTION(posix_kill)
+    Get the current process id (POSIX.1, 4.1.1) */
+ PHP_FUNCTION(posix_getpid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getpid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -486,7 +494,11 @@ PHP_FUNCTION(posix_getpid)
+    Get the parent process id (POSIX.1, 4.1.1) */
+ PHP_FUNCTION(posix_getppid)
+ {
+-	PHP_POSIX_RETURN_LONG_FUNC(getppid);
++#ifndef WASM_WASI
++	PHP_POSIX_RETURN_LONG_FUNC(getgid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -494,7 +506,11 @@ PHP_FUNCTION(posix_getppid)
+    Get the current user id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_getuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -502,7 +518,11 @@ PHP_FUNCTION(posix_getuid)
+    Get the current group id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_getgid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getgid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -510,7 +530,11 @@ PHP_FUNCTION(posix_getgid)
+    Get the current effective user id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_geteuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(geteuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -518,7 +542,11 @@ PHP_FUNCTION(posix_geteuid)
+    Get the current effective group id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_getegid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getegid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -526,7 +554,11 @@ PHP_FUNCTION(posix_getegid)
+    Set user id (POSIX.1, 4.2.2) */
+ PHP_FUNCTION(posix_setuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(setuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -534,7 +566,11 @@ PHP_FUNCTION(posix_setuid)
+    Set group id (POSIX.1, 4.2.2) */
+ PHP_FUNCTION(posix_setgid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(setgid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -543,7 +579,11 @@ PHP_FUNCTION(posix_setgid)
+ #ifdef HAVE_SETEUID
+ PHP_FUNCTION(posix_seteuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(seteuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ #endif
+ /* }}} */
+@@ -553,7 +593,11 @@ PHP_FUNCTION(posix_seteuid)
+ #ifdef HAVE_SETEGID
+ PHP_FUNCTION(posix_setegid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(setegid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ #endif
+ /* }}} */
+@@ -616,7 +660,11 @@ PHP_FUNCTION(posix_getlogin)
+    Get current process group id (POSIX.1, 4.3.1) */
+ PHP_FUNCTION(posix_getpgrp)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getpgrp);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -634,6 +682,7 @@ PHP_FUNCTION(posix_setsid)
+    Set process group id for job control (POSIX.1, 4.3.3) */
+ PHP_FUNCTION(posix_setpgid)
+ {
++#ifndef WASM_WASI
+ 	zend_long pid, pgid;
+ 
+ 	ZEND_PARSE_PARAMETERS_START(2, 2)
+@@ -645,6 +694,7 @@ PHP_FUNCTION(posix_setpgid)
+ 		POSIX_G(last_error) = errno;
+ 		RETURN_FALSE;
+ 	}
++#endif // WASM_WASI
+ 
+ 	RETURN_TRUE;
+ }
+@@ -819,6 +869,7 @@ PHP_FUNCTION(posix_ttyname)
+ 		default:
+ 			fd = zval_get_long(z_fd);
+ 	}
++#ifndef WASM_WASI
+ #if defined(ZTS) && defined(HAVE_TTYNAME_R) && defined(_SC_TTY_NAME_MAX)
+ 	buflen = sysconf(_SC_TTY_NAME_MAX);
+ 	if (buflen < 1) {
+@@ -839,6 +890,7 @@ PHP_FUNCTION(posix_ttyname)
+ 		RETURN_FALSE;
+ 	}
+ #endif
++#endif // WASM_WASI
+ 	RETURN_STRING(p);
+ }
+ /* }}} */
+@@ -994,6 +1046,7 @@ int php_posix_group_to_array(struct group *g, zval *array_group) /* {{{ */
+ 	zval array_members;
+ 	int count;
+ 
++#ifndef WASM_WASI
+ 	if (NULL == g)
+ 		return 0;
+ 
+@@ -1021,6 +1074,9 @@ int php_posix_group_to_array(struct group *g, zval *array_group) /* {{{ */
+ 	zend_hash_str_update(Z_ARRVAL_P(array_group), "members", sizeof("members")-1, &array_members);
+ 	add_assoc_long(array_group, "gid", g->gr_gid);
+ 	return 1;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -1080,6 +1136,7 @@ PHP_FUNCTION(posix_access)
+    Group database access (POSIX.1, 9.2.1) */
+ PHP_FUNCTION(posix_getgrnam)
+ {
++#ifndef WASM_WASI
+ 	char *name;
+ 	struct group *g;
+ 	size_t name_len;
+@@ -1128,6 +1185,9 @@ try_again:
+ #if defined(ZTS) && defined(HAVE_GETGRNAM_R) && defined(_SC_GETGR_R_SIZE_MAX)
+ 	efree(buf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -1135,6 +1195,7 @@ try_again:
+    Group database access (POSIX.1, 9.2.1) */
+ PHP_FUNCTION(posix_getgrgid)
+ {
++#ifndef WASM_WASI
+ 	zend_long gid;
+ #if defined(ZTS) && defined(HAVE_GETGRGID_R) && defined(_SC_GETGR_R_SIZE_MAX)
+ 	int ret;
+@@ -1187,11 +1248,15 @@ try_again:
+ #if defined(ZTS) && defined(HAVE_GETGRGID_R) && defined(_SC_GETGR_R_SIZE_MAX)
+ 	efree(grbuf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ int php_posix_passwd_to_array(struct passwd *pw, zval *return_value) /* {{{ */
+ {
++#ifndef WASM_WASI
+ 	if (NULL == pw)
+ 		return 0;
+ 	if (NULL == return_value || Z_TYPE_P(return_value) != IS_ARRAY)
+@@ -1205,6 +1270,9 @@ int php_posix_passwd_to_array(struct passwd *pw, zval *return_value) /* {{{ */
+ 	add_assoc_string(return_value, "dir",       pw->pw_dir);
+ 	add_assoc_string(return_value, "shell",     pw->pw_shell);
+ 	return 1;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -1212,6 +1280,7 @@ int php_posix_passwd_to_array(struct passwd *pw, zval *return_value) /* {{{ */
+    User database access (POSIX.1, 9.2.2) */
+ PHP_FUNCTION(posix_getpwnam)
+ {
++#ifndef WASM_WASI
+ 	struct passwd *pw;
+ 	char *name;
+ 	size_t name_len;
+@@ -1260,6 +1329,9 @@ try_again:
+ #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWNAM_R)
+ 	efree(buf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -1267,6 +1339,7 @@ try_again:
+    User database access (POSIX.1, 9.2.2) */
+ PHP_FUNCTION(posix_getpwuid)
+ {
++#ifndef WASM_WASI
+ 	zend_long uid;
+ #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWUID_R)
+ 	struct passwd _pw;
+@@ -1317,6 +1390,9 @@ try_again:
+ #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWUID_R)
+ 	efree(pwbuf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/session/mod_files.c b/ext/session/mod_files.c
+index cb8138e60a..49e9c19197 100644
+--- a/ext/session/mod_files.c
++++ b/ext/session/mod_files.c
+@@ -194,6 +194,7 @@ static void ps_files_open(ps_files *data, const char *key)
+ #endif
+ 
+ 		if (data->fd != -1) {
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ 			/* check that this session file was created by us or root – we
+ 			   don't want to end up accepting the sessions of another webapp
+@@ -213,6 +214,7 @@ static void ps_files_open(ps_files *data, const char *key)
+ 			do {
+ 				ret = flock(data->fd, LOCK_EX);
+ 			} while (ret == -1 && errno == EINTR);
++#endif // WASM_WASI
+ 
+ #ifdef F_SETFD
+ # ifndef FD_CLOEXEC
+diff --git a/ext/standard/basic_functions.c b/ext/standard/basic_functions.c
+index 64f27ef5af..d088a659b6 100644
+--- a/ext/standard/basic_functions.c
++++ b/ext/standard/basic_functions.c
+@@ -61,11 +61,13 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
+ #include <sys/stat.h>
+ #endif
+ 
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ # include <netdb.h>
+ #else
+ #include "win32/inet.h"
+ #endif
++#endif // WASM_WASI
+ 
+ #if HAVE_ARPA_INET_H
+ # include <arpa/inet.h>
+@@ -3830,9 +3832,11 @@ PHP_RSHUTDOWN_FUNCTION(basic) /* {{{ */
+ 
+ 	BG(mt_rand_is_seeded) = 0;
+ 
++#ifndef WASM_WASI
+ 	if (BG(umask) != -1) {
+ 		umask(BG(umask));
+ 	}
++#endif // WASM_WASI
+ 
+ 	/* Check if locale was changed and change it back
+ 	 * to the value in startup environment */
+@@ -5954,6 +5958,7 @@ PHP_FUNCTION(move_uploaded_file)
+ 
+ 	if (VCWD_RENAME(path, new_path) == 0) {
+ 		successful = 1;
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ 		oldmask = umask(077);
+ 		umask(oldmask);
+@@ -5964,6 +5969,7 @@ PHP_FUNCTION(move_uploaded_file)
+ 			php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+ 		}
+ #endif
++#endif // WASM_WASI
+ 	} else if (php_copy_file_ex(path, new_path, STREAM_DISABLE_OPEN_BASEDIR) == SUCCESS) {
+ 		VCWD_UNLINK(path);
+ 		successful = 1;
+diff --git a/ext/standard/dns.c b/ext/standard/dns.c
+index dc85c45e1d..e22a402a16 100644
+--- a/ext/standard/dns.c
++++ b/ext/standard/dns.c
+@@ -36,7 +36,9 @@
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif
+ #ifdef _OSD_POSIX
+ #undef STATUS
+ #undef T_UNSPEC
+@@ -174,6 +176,7 @@ PHP_FUNCTION(gethostbyaddr)
+ /* {{{ php_gethostbyaddr */
+ static zend_string *php_gethostbyaddr(char *ip)
+ {
++#ifndef WASM_WASI
+ #if HAVE_IPV6 && HAVE_INET_PTON
+ 	struct in6_addr addr6;
+ #endif
+@@ -203,6 +206,9 @@ static zend_string *php_gethostbyaddr(char *ip)
+ 	}
+ 
+ 	return zend_string_init(hp->h_name, strlen(hp->h_name), 0);
++#else
++	return NULL;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -231,6 +237,7 @@ PHP_FUNCTION(gethostbyname)
+    Return a list of IP addresses that a given hostname resolves to. */
+ PHP_FUNCTION(gethostbynamel)
+ {
++#ifndef WASM_WASI
+ 	char *hostname;
+ 	size_t hostname_len;
+ 	struct hostent *hp;
+@@ -265,12 +272,16 @@ PHP_FUNCTION(gethostbynamel)
+ 		in = *h_addr_entry;
+ 		add_next_index_string(return_value, inet_ntoa(in));
+ 	}
++#else
++	RETURN_FALSE;
++#endif //WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ php_gethostbyname */
+ static zend_string *php_gethostbyname(char *name)
+ {
++#ifndef WASM_WASI
+ 	struct hostent *hp;
+ 	struct in_addr *h_addr_0; /* Don't call this h_addr, it's a macro! */
+ 	struct in_addr in;
+@@ -291,6 +302,9 @@ static zend_string *php_gethostbyname(char *name)
+ 
+ 	address = inet_ntoa(in);
+ 	return zend_string_init(address, strlen(address), 0);
++#else
++	return NULL;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/exec.c b/ext/standard/exec.c
+index db92ea724b..d7e26facad 100644
+--- a/ext/standard/exec.c
++++ b/ext/standard/exec.c
+@@ -92,6 +92,7 @@ PHP_MINIT_FUNCTION(exec)
+  */
+ PHPAPI int php_exec(int type, char *cmd, zval *array, zval *return_value)
+ {
++#ifndef WASM_WASI
+ 	FILE *fp;
+ 	char *buf;
+ 	size_t l = 0;
+@@ -207,6 +208,9 @@ done:
+ err:
+ 	pclose_return = -1;
+ 	goto done;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -527,6 +531,7 @@ PHP_FUNCTION(escapeshellarg)
+    Execute command via shell and return complete output as string */
+ PHP_FUNCTION(shell_exec)
+ {
++#ifndef WASM_WASI
+ 	FILE *in;
+ 	char *command;
+ 	size_t command_len;
+@@ -562,6 +567,9 @@ PHP_FUNCTION(shell_exec)
+ 	if (ret && ZSTR_LEN(ret) > 0) {
+ 		RETVAL_STR(ret);
+ 	}
++#else
++	RETURN_FALSE;
++#endif
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/file.c b/ext/standard/file.c
+index 3bd3421603..bc23639afd 100644
+--- a/ext/standard/file.c
++++ b/ext/standard/file.c
+@@ -56,7 +56,9 @@
+ # endif
+ # include <sys/socket.h>
+ # include <netinet/in.h>
++#ifndef WASM_WASI
+ # include <netdb.h>
++#endif
+ # if HAVE_ARPA_INET_H
+ #  include <arpa/inet.h>
+ # endif
+@@ -923,6 +925,7 @@ PHPAPI PHP_FUNCTION(fclose)
+    Execute a command and open either a read or a write pipe to it */
+ PHP_FUNCTION(popen)
+ {
++#ifndef WASM_WASI
+ 	char *command, *mode;
+ 	size_t command_len, mode_len;
+ 	FILE *fp;
+@@ -961,6 +964,9 @@ PHP_FUNCTION(popen)
+ 	}
+ 
+ 	efree(posix_mode);
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -1410,6 +1416,7 @@ PHP_FUNCTION(readfile)
+    Return or change the umask */
+ PHP_FUNCTION(umask)
+ {
++#ifndef WASM_WASI
+ 	zend_long mask = 0;
+ 	int oldumask;
+ 
+@@ -1431,6 +1438,9 @@ PHP_FUNCTION(umask)
+ 	}
+ 
+ 	RETURN_LONG(oldumask);
++#else
++	RETURN_LONG(0);
++#endif
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/filestat.c b/ext/standard/filestat.c
+index be6b2dda09..97c99ad008 100644
+--- a/ext/standard/filestat.c
++++ b/ext/standard/filestat.c
+@@ -64,7 +64,9 @@
+ # ifdef PHP_WIN32
+ #  include "win32/grp.h"
+ # else
++#ifndef WASM_WASI
+ #  include <grp.h>
++#endif // WASM_WASI
+ # endif
+ #endif
+ 
+@@ -325,12 +327,16 @@ PHPAPI int php_get_gid_by_name(const char *name, gid_t *gid)
+ 		efree(grbuf);
+ 		*gid = gr.gr_gid;
+ #else
++#ifndef WASM_WASI
+ 		struct group *gr = getgrnam(name);
+ 
+ 		if (!gr) {
+ 			return FAILURE;
+ 		}
+ 		*gid = gr->gr_gid;
++#else
++		*gid = 0;
++#endif // WASM_WASI
+ #endif
+ 		return SUCCESS;
+ }
+@@ -402,6 +408,7 @@ static void php_do_chgrp(INTERNAL_FUNCTION_PARAMETERS, int do_lchgrp) /* {{{ */
+ 		RETURN_FALSE;
+ 	}
+ 
++#ifndef WASM_WASI
+ 	if (do_lchgrp) {
+ #if HAVE_LCHOWN
+ 		ret = VCWD_LCHOWN(filename, -1, gid);
+@@ -413,6 +420,7 @@ static void php_do_chgrp(INTERNAL_FUNCTION_PARAMETERS, int do_lchgrp) /* {{{ */
+ 		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+ 		RETURN_FALSE;
+ 	}
++#endif // WASM_WASI
+ 	RETURN_TRUE;
+ #endif
+ }
+@@ -461,12 +469,16 @@ PHPAPI uid_t php_get_uid_by_name(const char *name, uid_t *uid)
+ 		efree(pwbuf);
+ 		*uid = pw.pw_uid;
+ #else
++#ifndef WASM_WASI
+ 		struct passwd *pw = getpwnam(name);
+ 
+ 		if (!pw) {
+ 			return FAILURE;
+ 		}
+ 		*uid = pw->pw_uid;
++#else
++		*uid = 0;
++#endif // WASM_WASI
+ #endif
+ 		return SUCCESS;
+ }
+@@ -474,6 +486,7 @@ PHPAPI uid_t php_get_uid_by_name(const char *name, uid_t *uid)
+ 
+ static void php_do_chown(INTERNAL_FUNCTION_PARAMETERS, int do_lchown) /* {{{ */
+ {
++#ifndef WASM_WASI
+ 	char *filename;
+ 	size_t filename_len;
+ 	zval *user;
+@@ -552,6 +565,9 @@ static void php_do_chown(INTERNAL_FUNCTION_PARAMETERS, int do_lchown) /* {{{ */
+ 	}
+ 	RETURN_TRUE;
+ #endif
++#else
++	RETURN_TRUE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -583,6 +599,7 @@ PHP_FUNCTION(lchown)
+    Change file mode */
+ PHP_FUNCTION(chmod)
+ {
++#ifndef WASM_WASI
+ 	char *filename;
+ 	size_t filename_len;
+ 	zend_long mode;
+@@ -621,6 +638,7 @@ PHP_FUNCTION(chmod)
+ 		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+ 		RETURN_FALSE;
+ 	}
++#endif // WASM_WASI
+ 	RETURN_TRUE;
+ }
+ /* }}} */
+@@ -832,6 +850,7 @@ PHPAPI void php_stat(const char *filename, size_t filename_length, int type, zva
+ 
+ 	stat_sb = &ssb.sb;
+ 
++#ifndef WASM_WASI
+ 	if (type >= FS_IS_W && type <= FS_IS_X) {
+ 		if(ssb.sb.st_uid==getuid()) {
+ 			rmask=S_IRUSR;
+@@ -872,6 +891,7 @@ PHPAPI void php_stat(const char *filename, size_t filename_length, int type, zva
+ 			}
+ 		}
+ 	}
++#endif // WASM_WASI
+ 
+ 	switch (type) {
+ 	case FS_PERMS:
+@@ -900,9 +920,11 @@ PHPAPI void php_stat(const char *filename, size_t filename_length, int type, zva
+ 		case S_IFDIR: RETURN_STRING("dir");
+ 		case S_IFBLK: RETURN_STRING("block");
+ 		case S_IFREG: RETURN_STRING("file");
++#ifndef WASM_WASI
+ #if defined(S_IFSOCK) && !defined(PHP_WIN32)
+ 		case S_IFSOCK: RETURN_STRING("socket");
+ #endif
++#endif // WASM_WASI
+ 		}
+ 		php_error_docref(NULL, E_NOTICE, "Unknown file type (%d)", ssb.sb.st_mode&S_IFMT);
+ 		RETURN_STRING("unknown");
+diff --git a/ext/standard/flock_compat.c b/ext/standard/flock_compat.c
+index 8bbf6fb895..b9d88f55d3 100644
+--- a/ext/standard/flock_compat.c
++++ b/ext/standard/flock_compat.c
+@@ -39,7 +39,12 @@ PHPAPI int flock(int fd, int operation)
+ #endif /* !defined(HAVE_FLOCK) */
+ 
+ PHPAPI int php_flock(int fd, int operation)
+-#if HAVE_STRUCT_FLOCK /* {{{ */
++#if defined(WASM_WASI)
++{
++	errno = 0;
++	return 0;
++}
++#elif HAVE_STRUCT_FLOCK /* {{{ */
+ {
+ 	struct flock flck;
+ 	int ret;
+diff --git a/ext/standard/ftp_fopen_wrapper.c b/ext/standard/ftp_fopen_wrapper.c
+index 3a7dec4a3b..6df6f763ed 100644
+--- a/ext/standard/ftp_fopen_wrapper.c
++++ b/ext/standard/ftp_fopen_wrapper.c
+@@ -50,7 +50,9 @@
+ #include <winsock2.h>
+ #else
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+diff --git a/ext/standard/http_fopen_wrapper.c b/ext/standard/http_fopen_wrapper.c
+index 4d918b21e6..886de55f61 100644
+--- a/ext/standard/http_fopen_wrapper.c
++++ b/ext/standard/http_fopen_wrapper.c
+@@ -53,7 +53,9 @@
+ #include <winsock2.h>
+ #else
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+diff --git a/ext/standard/link.c b/ext/standard/link.c
+index 1117049344..5a02dcb022 100644
+--- a/ext/standard/link.c
++++ b/ext/standard/link.c
+@@ -45,7 +45,9 @@
+ #ifdef PHP_WIN32
+ #include "win32/grp.h"
+ #else
+-#include <grp.h>
++#ifndef WASM_WASI
++#  include <grp.h>
++#endif // WASM_WASI
+ #endif
+ #endif
+ #include <errno.h>
+diff --git a/ext/standard/mail.c b/ext/standard/mail.c
+index b27923aca1..cb633f5253 100644
+--- a/ext/standard/mail.c
++++ b/ext/standard/mail.c
+@@ -462,6 +462,7 @@ static int php_mail_detect_multiple_crlf(char *hdr) {
+  */
+ PHPAPI int php_mail(char *to, char *subject, char *message, char *headers, char *extra_cmd)
+ {
++#ifndef WASM_WASI
+ #ifdef PHP_WIN32
+ 	int tsm_err;
+ 	char *tsm_errmsg = NULL;
+@@ -635,6 +636,9 @@ PHPAPI int php_mail(char *to, char *subject, char *message, char *headers, char
+ 	}
+ 
+ 	MAIL_RET(1); /* never reached */
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/microtime.c b/ext/standard/microtime.c
+index 9bd45e188d..e513827cce 100644
+--- a/ext/standard/microtime.c
++++ b/ext/standard/microtime.c
+@@ -132,6 +132,7 @@ PHP_FUNCTION(getrusage)
+ 	PHP_RUSAGE_PARA(ru_majflt);
+ 	PHP_RUSAGE_PARA(ru_maxrss);
+ #elif !defined(_OSD_POSIX)
++#ifndef WASM_WASI
+ 	PHP_RUSAGE_PARA(ru_oublock);
+ 	PHP_RUSAGE_PARA(ru_inblock);
+ 	PHP_RUSAGE_PARA(ru_msgsnd);
+@@ -145,6 +146,7 @@ PHP_FUNCTION(getrusage)
+ 	PHP_RUSAGE_PARA(ru_nvcsw);
+ 	PHP_RUSAGE_PARA(ru_nivcsw);
+ 	PHP_RUSAGE_PARA(ru_nswap);
++#endif // WASM_WASI
+ #endif /*_OSD_POSIX*/
+ 	PHP_RUSAGE_PARA(ru_utime.tv_usec);
+ 	PHP_RUSAGE_PARA(ru_utime.tv_sec);
+diff --git a/ext/standard/net.c b/ext/standard/net.c
+index 600ef8d0e0..89d4b65066 100644
+--- a/ext/standard/net.c
++++ b/ext/standard/net.c
+@@ -40,7 +40,9 @@
+ # include <Ws2tcpip.h>
+ # include <iphlpapi.h>
+ #else
++#ifndef WASM_WASI
+ # include <netdb.h>
++#endif // WASM_WASI
+ #endif
+ 
+ PHPAPI zend_string* php_inet_ntop(const struct sockaddr *addr) {
+@@ -82,6 +84,7 @@ PHPAPI zend_string* php_inet_ntop(const struct sockaddr *addr) {
+ 			/* fallthrough */
+ #endif
+ 		case AF_INET: {
++#ifndef WASM_WASI
+ 			zend_string *ret = zend_string_alloc(NI_MAXHOST, 0);
+ 			if (getnameinfo(addr, addrlen, ZSTR_VAL(ret), NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == SUCCESS) {
+ 				/* Also demangle numeric host with %name suffix */
+@@ -92,6 +95,9 @@ PHPAPI zend_string* php_inet_ntop(const struct sockaddr *addr) {
+ 			}
+ 			zend_string_efree(ret);
+ 			break;
++#else
++			return NULL;
++#endif // WASM_WASI
+ 		}
+ 	}
+ 
+diff --git a/ext/standard/pageinfo.c b/ext/standard/pageinfo.c
+index e0533efdd0..422f925dbc 100644
+--- a/ext/standard/pageinfo.c
++++ b/ext/standard/pageinfo.c
+@@ -33,7 +33,9 @@
+ # ifdef PHP_WIN32
+ #  include "win32/grp.h"
+ # else
++#ifndef WASM_WASI
+ #  include <grp.h>
++#endif // WASM_WASI
+ # endif
+ #endif
+ #ifdef PHP_WIN32
+@@ -68,8 +70,10 @@ PHPAPI void php_statpage(void)
+ 			BG(page_inode) = pstat->st_ino;
+ 			BG(page_mtime) = pstat->st_mtime;
+ 		} else { /* handler for situations where there is no source file, ex. php -r */
++#ifndef WASM_WASI
+ 			BG(page_uid) = getuid();
+ 			BG(page_gid) = getgid();
++#endif // WASM_WASI
+ 		}
+ 	}
+ }
+@@ -79,21 +83,30 @@ PHPAPI void php_statpage(void)
+  */
+ zend_long php_getuid(void)
+ {
++#ifndef WASM_WASI
+ 	php_statpage();
+ 	return (BG(page_uid));
++#else
++	return 0;
++#endif //WASM_WASI
+ }
+ /* }}} */
+ 
+ zend_long php_getgid(void)
+ {
++#ifndef WASM_WASI
+ 	php_statpage();
+ 	return (BG(page_gid));
++#else
++	return 0;
++#endif //WASM_WASI
+ }
+ 
+ /* {{{ proto int getmyuid(void)
+    Get PHP script owner's UID */
+ PHP_FUNCTION(getmyuid)
+ {
++#ifndef WASM_WASI
+ 	zend_long uid;
+ 
+ 	if (zend_parse_parameters_none() == FAILURE) {
+@@ -106,6 +119,9 @@ PHP_FUNCTION(getmyuid)
+ 	} else {
+ 		RETURN_LONG(uid);
+ 	}
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/php_fopen_wrapper.c b/ext/standard/php_fopen_wrapper.c
+index 295751f0db..e243a115b9 100644
+--- a/ext/standard/php_fopen_wrapper.c
++++ b/ext/standard/php_fopen_wrapper.c
+@@ -248,13 +248,17 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			static int cli_in = 0;
+ 			fd = STDIN_FILENO;
+ 			if (cli_in) {
++#ifndef WASM_WASI
+ 				fd = dup(fd);
++#endif // WASM_WASI
+ 			} else {
+ 				cli_in = 1;
+ 				file = stdin;
+ 			}
+ 		} else {
++#ifndef WASM_WASI
+ 			fd = dup(STDIN_FILENO);
++#endif // WASM_WASI
+ 		}
+ #ifdef PHP_WIN32
+ 		pipe_requested = 1;
+@@ -264,13 +268,17 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			static int cli_out = 0;
+ 			fd = STDOUT_FILENO;
+ 			if (cli_out++) {
++#ifndef WASM_WASI
+ 				fd = dup(fd);
++#endif // WASM_WASI
+ 			} else {
+ 				cli_out = 1;
+ 				file = stdout;
+ 			}
+ 		} else {
++#ifndef WASM_WASI
+ 			fd = dup(STDOUT_FILENO);
++#endif // WASM_WASI
+ 		}
+ #ifdef PHP_WIN32
+ 		pipe_requested = 1;
+@@ -280,13 +288,17 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			static int cli_err = 0;
+ 			fd = STDERR_FILENO;
+ 			if (cli_err++) {
++#ifndef WASM_WASI
+ 				fd = dup(fd);
++#endif // WASM_WASI
+ 			} else {
+ 				cli_err = 1;
+ 				file = stderr;
+ 			}
+ 		} else {
++#ifndef WASM_WASI
+ 			fd = dup(STDERR_FILENO);
++#endif // WASM_WASI
+ 		}
+ #ifdef PHP_WIN32
+ 		pipe_requested = 1;
+@@ -319,7 +331,7 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			return NULL;
+ 		}
+ 
+-#if HAVE_UNISTD_H
++#if HAVE_UNISTD_H && !defined(WASM_WASI)
+ 		dtablesize = getdtablesize();
+ #else
+ 		dtablesize = INT_MAX;
+@@ -331,6 +343,7 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			return NULL;
+ 		}
+ 
++#ifndef WASM_WASI
+ 		fd = dup((int)fildes_ori);
+ 		if (fd == -1) {
+ 			php_stream_wrapper_log_error(wrapper, options,
+@@ -338,6 +351,7 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 				"[%d]: %s", fildes_ori, errno, strerror(errno));
+ 			return NULL;
+ 		}
++#endif // WASM_WASI
+ 	} else if (!strncasecmp(path, "filter/", 7)) {
+ 		/* Save time/memory when chain isn't specified */
+ 		if (strchr(mode, 'r') || strchr(mode, '+')) {
+diff --git a/main/fastcgi.c b/main/fastcgi.c
+index f8044ffce3..681bfbbafe 100644
+--- a/main/fastcgi.c
++++ b/main/fastcgi.c
+@@ -71,7 +71,9 @@ static int is_impersonate = 0;
+ # include <netinet/in.h>
+ # include <netinet/tcp.h>
+ # include <arpa/inet.h>
++#ifndef WASM_WASI
+ # include <netdb.h>
++#endif
+ # include <signal.h>
+ 
+ # if defined(HAVE_POLL_H) && defined(HAVE_POLL)
+@@ -433,6 +435,7 @@ static void fcgi_signal_handler(int signo)
+ 
+ static void fcgi_setup_signals(void)
+ {
++#ifndef WASM_WASI
+ 	struct sigaction new_sa, old_sa;
+ 
+ 	sigemptyset(&new_sa.sa_mask);
+@@ -444,6 +447,7 @@ static void fcgi_setup_signals(void)
+ 	if (old_sa.sa_handler == SIG_DFL) {
+ 		sigaction(SIGPIPE, &new_sa, NULL);
+ 	}
++#endif // WASM_WASI
+ }
+ #endif
+ 
+@@ -533,6 +537,8 @@ int fcgi_init(void)
+ 		} else {
+ 			return is_fastcgi = 0;
+ 		}
++#elif defined(WASM_WASI)
++		return is_fastcgi = 0;
+ #else
+ 		errno = 0;
+ 		if (getpeername(0, (struct sockaddr *)&sa, &len) != 0 && errno == ENOTCONN) {
+@@ -682,6 +688,7 @@ int fcgi_listen(const char *path, int backlog)
+ 
+ 	/* Prepare socket address */
+ 	if (tcp) {
++#ifndef WASM_WASI
+ 		memset(&sa.sa_inet, 0, sizeof(sa.sa_inet));
+ 		sa.sa_inet.sin_family = AF_INET;
+ 		sa.sa_inet.sin_port = htons(port);
+@@ -770,6 +777,7 @@ int fcgi_listen(const char *path, int backlog)
+ 	if (!tcp) {
+ 		chmod(path, 0777);
+ 	} else {
++#endif // WASM_WASI
+ 		char *ip = getenv("FCGI_WEB_SERVER_ADDRS");
+ 		char *cur, *end;
+ 		int n;
+@@ -1102,7 +1110,9 @@ static int fcgi_read_request(fcgi_request *req)
+ 			int on = 1;
+ # endif
+ 
++#ifndef WASM_WASI
+ 			setsockopt(req->fd, IPPROTO_TCP, TCP_NODELAY, (char*)&on, sizeof(on));
++#endif // WASM_WASI
+ 			req->nodelay = 1;
+ 		}
+ #endif
+@@ -1412,7 +1422,9 @@ int fcgi_accept_request(fcgi_request *req)
+ 					client_sa = sa;
+ 					if (req->fd >= 0 && !fcgi_is_allowed()) {
+ 						fcgi_log(FCGI_ERROR, "Connection disallowed: IP address '%s' has been dropped.", fcgi_get_last_client_ip());
++#ifndef WASM_WASI
+ 						closesocket(req->fd);
++#endif // WASM_WASI
+ 						req->fd = -1;
+ 						continue;
+ 					}
+diff --git a/main/fopen_wrappers.c b/main/fopen_wrappers.c
+index 27135020fa..955c73c741 100644
+--- a/main/fopen_wrappers.c
++++ b/main/fopen_wrappers.c
+@@ -55,7 +55,9 @@
+ #include <winsock2.h>
+ #else
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+diff --git a/main/main.c b/main/main.c
+index 0b33b2b56c..1f6b8a48e0 100644
+--- a/main/main.c
++++ b/main/main.c
+@@ -1502,6 +1502,7 @@ static ZEND_COLD void php_error_cb(int type, const char *error_filename, const u
+  */
+ PHPAPI char *php_get_current_user(void)
+ {
++#ifndef WASM_WASI
+ 	zend_stat_t *pstat;
+ 
+ 	if (SG(request_info).current_user) {
+@@ -1564,6 +1565,9 @@ PHPAPI char *php_get_current_user(void)
+ 		return SG(request_info).current_user;
+ #endif
+ 	}
++#else
++	return "";
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/main/network.c b/main/network.c
+index 091fc17e6f..b6d6759a85 100644
+--- a/main/network.c
++++ b/main/network.c
+@@ -56,7 +56,9 @@
+ 
+ #ifndef PHP_WIN32
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+@@ -157,6 +159,7 @@ PHPAPI void php_network_freeaddresses(struct sockaddr **sal)
+  */
+ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct sockaddr ***sal, zend_string **error_string)
+ {
++#ifndef WASM_WASI
+ 	struct sockaddr **sap;
+ 	int n;
+ #if HAVE_GETADDRINFO
+@@ -275,6 +278,9 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
+ 
+ 	*sap = NULL;
+ 	return n;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -310,6 +316,7 @@ PHPAPI int php_network_connect_socket(php_socket_t sockfd,
+ 		zend_string **error_string,
+ 		int *error_code)
+ {
++#ifndef WASM_WASI
+ 	php_non_blocking_flags_t orig_flags;
+ 	int n;
+ 	int error = 0;
+@@ -387,6 +394,9 @@ ok:
+ 		}
+ 	}
+ 	return ret;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -431,7 +441,11 @@ php_socket_t php_network_bind_socket_to_local_addr(const char *host, unsigned po
+ 		sa = *sal;
+ 
+ 		/* create a socket for this address */
++#ifndef WASM_WASI
+ 		sock = socket(sa->sa_family, socktype, 0);
++#else
++		sock = SOCK_ERR;
++#endif // WASM_WASI 
+ 
+ 		if (sock == SOCK_ERR) {
+ 			continue;
+@@ -460,31 +474,45 @@ php_socket_t php_network_bind_socket_to_local_addr(const char *host, unsigned po
+ 			/* attempt to bind */
+ 
+ #ifdef SO_REUSEADDR
++#ifndef WASM_WASI
+ 			setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI 
+ #endif
+ #ifdef IPV6_V6ONLY
+ 			if (sockopts & STREAM_SOCKOP_IPV6_V6ONLY) {
+ 				int ipv6_val = !!(sockopts & STREAM_SOCKOP_IPV6_V6ONLY_ENABLED);
++#ifndef WASM_WASI
+ 				setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&ipv6_val, sizeof(sockoptval));
++#endif // WASM_WASI 
+ 			}
+ #endif
+ #ifdef SO_REUSEPORT
+ 			if (sockopts & STREAM_SOCKOP_SO_REUSEPORT) {
++#ifndef WASM_WASI
+ 				setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI 
+ 			}
+ #endif
+ #ifdef SO_BROADCAST
+ 			if (sockopts & STREAM_SOCKOP_SO_BROADCAST) {
++#ifndef WASM_WASI
+ 				setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI 
+ 			}
+ #endif
+ #ifdef TCP_NODELAY
+ 			if (sockopts & STREAM_SOCKOP_TCP_NODELAY) {
++#ifndef WASM_WASI
+ 				setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI 
+ 			}
+ #endif
+ 
++#ifndef WASM_WASI
+ 			n = bind(sock, sa, socklen);
++#else
++			n = SOCK_CONN_ERR;
++#endif // WASM_WASI 
+ 
+ 			if (n != SOCK_CONN_ERR) {
+ 				goto bound;
+@@ -614,6 +642,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
+ 		socklen_t *addrlen
+ 		)
+ {
++#ifndef WASM_WASI
+ 	if (addr) {
+ 		*addr = emalloc(sl);
+ 		memcpy(*addr, sa, sl);
+@@ -667,6 +696,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
+ 		}
+ 
+ 	}
++#endif // WASM_WASI
+ }
+ 
+ PHPAPI int php_network_get_peer_name(php_socket_t sock,
+@@ -675,6 +705,7 @@ PHPAPI int php_network_get_peer_name(php_socket_t sock,
+ 		socklen_t *addrlen
+ 		)
+ {
++#ifndef WASM_WASI
+ 	php_sockaddr_storage sa;
+ 	socklen_t sl = sizeof(sa);
+ 	memset(&sa, 0, sizeof(sa));
+@@ -687,6 +718,9 @@ PHPAPI int php_network_get_peer_name(php_socket_t sock,
+ 		return 0;
+ 	}
+ 	return -1;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ 
+ PHPAPI int php_network_get_sock_name(php_socket_t sock,
+@@ -695,6 +729,7 @@ PHPAPI int php_network_get_sock_name(php_socket_t sock,
+ 		socklen_t *addrlen
+ 		)
+ {
++#ifndef WASM_WASI
+ 	php_sockaddr_storage sa;
+ 	socklen_t sl = sizeof(sa);
+ 	memset(&sa, 0, sizeof(sa));
+@@ -707,7 +742,9 @@ PHPAPI int php_network_get_sock_name(php_socket_t sock,
+ 		return 0;
+ 	}
+ 	return -1;
+-
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ 
+ 
+@@ -753,7 +790,9 @@ PHPAPI php_socket_t php_network_accept_incoming(php_socket_t srvsock,
+ 					);
+ 			if (tcp_nodelay) {
+ #ifdef TCP_NODELAY
++#ifndef WASM_WASI
+ 				setsockopt(clisock, IPPROTO_TCP, TCP_NODELAY, (char*)&tcp_nodelay, sizeof(tcp_nodelay));
++#endif // WASM_WASI
+ #endif
+ 			}
+ 		} else {
+@@ -870,7 +909,9 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
+ 						php_error_docref(NULL, E_WARNING, "Invalid IP Address: %s", bindto);
+ 						goto skip_bind;
+ 					}
++#ifndef WASM_WASI
+ 					memset(&(in4->sin_zero), 0, sizeof(in4->sin_zero));
++#endif // WASM_WASI
+ 				}
+ #if HAVE_IPV6 && HAVE_INET_PTON
+ 				 else { /* IPV6 */
+@@ -906,7 +947,9 @@ skip_bind:
+ 			{
+ 				int val = 1;
+ 				if (sockopts & STREAM_SOCKOP_SO_BROADCAST) {
++#ifndef WASM_WASI
+ 					setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char*)&val, sizeof(val));
++#endif // WASM_WASI
+ 				}
+ 			}
+ #endif
+@@ -915,7 +958,9 @@ skip_bind:
+ 			{
+ 				int val = 1;
+ 				if (sockopts & STREAM_SOCKOP_TCP_NODELAY) {
++#ifndef WASM_WASI
+ 					setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char*)&val, sizeof(val));
++#endif // WASM_WASI
+ 				}
+ 			}
+ #endif
+@@ -1320,6 +1365,7 @@ struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char *
+ #endif
+ 
+ PHPAPI struct hostent*	php_network_gethostbyname(char *name) {
++#ifndef WASM_WASI
+ #if !defined(HAVE_GETHOSTBYNAME_R)
+ 	return gethostbyname(name);
+ #else
+@@ -1334,4 +1380,7 @@ PHPAPI struct hostent*	php_network_gethostbyname(char *name) {
+ 
+ 	return gethostname_re(name, &FG(tmp_host_info), &FG(tmp_host_buf), &FG(tmp_host_buf_len));
+ #endif
++#else
++	return NULL;
++#endif // WASM_WASI
+ }
+diff --git a/main/php_open_temporary_file.c b/main/php_open_temporary_file.c
+index b15dec03e4..8667fc0d3f 100644
+--- a/main/php_open_temporary_file.c
++++ b/main/php_open_temporary_file.c
+@@ -32,7 +32,9 @@
+ #include <sys/param.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+@@ -99,7 +101,7 @@ static int php_do_open_temporary_file(const char *path, const char *pfx, zend_st
+ 	char cwd[MAXPATHLEN];
+ 	cwd_state new_state;
+ 	int fd = -1;
+-#ifndef HAVE_MKSTEMP
++#if !defined(HAVE_MKSTEMP) || defined(WASM_WASI)
+ 	int open_flags = O_CREAT | O_TRUNC | O_RDWR
+ #ifdef PHP_WIN32
+ 		| _O_BINARY
+@@ -179,6 +181,8 @@ static int php_do_open_temporary_file(const char *path, const char *pfx, zend_st
+ 	free(pfxw);
+ #elif defined(HAVE_MKSTEMP)
+ 	fd = mkstemp(opened_path);
++#elif defined(WASM_WASI)
++	fd = VCWD_OPEN(opened_path, open_flags);
+ #else
+ 	if (mktemp(opened_path)) {
+ 		fd = VCWD_OPEN(opened_path, open_flags);
+diff --git a/main/php_syslog.c b/main/php_syslog.c
+index 987ef9cc0c..706ebd63e6 100644
+--- a/main/php_syslog.c
++++ b/main/php_syslog.c
+@@ -56,6 +56,7 @@ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
+ #else
+ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
+ {
++#ifndef WASM_WASI
+ 	const char *ptr;
+ 	unsigned char c;
+ 	smart_string fbuf = {0};
+@@ -112,6 +113,7 @@ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
+ 
+ 	smart_string_free(&fbuf);
+ 	smart_string_free(&sbuf);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ #endif
+diff --git a/main/streams/plain_wrapper.c b/main/streams/plain_wrapper.c
+index 4d10e688b5..db01dc2917 100644
+--- a/main/streams/plain_wrapper.c
++++ b/main/streams/plain_wrapper.c
+@@ -475,7 +475,9 @@ static int php_stdiop_close(php_stream *stream, int close_handle)
+ 		if (data->file) {
+ 			if (data->is_process_pipe) {
+ 				errno = 0;
++#ifndef WASM_WASI
+ 				ret = pclose(data->file);
++#endif
+ 
+ #if HAVE_SYS_WAIT_H
+ 				if (WIFEXITED(ret)) {
+@@ -1240,12 +1242,17 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
+ 			zend_stat_t sb;
+ # if !defined(ZTS) && !defined(TSRM_WIN32)
+             /* not sure what to do in ZTS case, umask is not thread-safe */
++#ifndef WASM_WASI
+ 			int oldmask = umask(077);
++#else
++			int oldmask = 077;
++#endif // WASM_WASI
+ # endif
+ 			int success = 0;
+ 			if (php_copy_file(url_from, url_to) == SUCCESS) {
+ 				if (VCWD_STAT(url_from, &sb) == 0) {
+ 					success = 1;
++#ifndef WASM_WASI
+ #  if !defined(TSRM_WIN32)
+ 					/*
+ 					 * Try to set user and permission info on the target.
+@@ -1270,6 +1277,7 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
+ 						}
+ 					}
+ #  endif
++#endif // WASM_WASI
+ 					if (success) {
+ 						VCWD_UNLINK(url_from);
+ 					}
+@@ -1280,7 +1288,9 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
+ 				php_error_docref2(NULL, url_from, url_to, E_WARNING, "%s", strerror(errno));
+ 			}
+ #  if !defined(ZTS) && !defined(TSRM_WIN32)
++#ifndef WASM_WASI
+ 			umask(oldmask);
++#endif // WASM_WASI
+ #  endif
+ 			return success;
+ 		}
+@@ -1464,7 +1474,11 @@ static int php_plain_files_metadata(php_stream_wrapper *wrapper, const char *url
+ 			} else {
+ 				uid = (uid_t)*(long *)value;
+ 			}
++#ifndef WASM_WASI
+ 			ret = VCWD_CHOWN(url, uid, -1);
++#else
++			ret = 0;
++#endif // WASM_WASI
+ 			break;
+ 		case PHP_STREAM_META_GROUP:
+ 		case PHP_STREAM_META_GROUP_NAME:
+@@ -1476,12 +1490,20 @@ static int php_plain_files_metadata(php_stream_wrapper *wrapper, const char *url
+ 			} else {
+ 				gid = (gid_t)*(long *)value;
+ 			}
++#ifndef WASM_WASI
+ 			ret = VCWD_CHOWN(url, -1, gid);
++#else
++			ret = 0;
++#endif // WASM_WASI
+ 			break;
+ #endif
+ 		case PHP_STREAM_META_ACCESS:
+ 			mode = (mode_t)*(zend_long *)value;
++#ifndef WASM_WASI
+ 			ret = VCWD_CHMOD(url, mode);
++#else
++			ret = 0;
++#endif // WASM_WASI
+ 			break;
+ 		default:
+ 			php_error_docref1(NULL, url, E_WARNING, "Unknown option %d for stream_metadata", option);
+diff --git a/main/streams/xp_socket.c b/main/streams/xp_socket.c
+index 46b23b63ad..33781801aa 100644
+--- a/main/streams/xp_socket.c
++++ b/main/streams/xp_socket.c
+@@ -217,7 +217,9 @@ static int php_sockop_close(php_stream *stream, int close_handle)
+ 				n = php_pollfd_for_ms(sock->socket, POLLOUT, 500);
+ 			} while (n == -1 && php_socket_errno() == EINTR);
+ #endif
++#ifndef WASM_WASI
+ 			closesocket(sock->socket);
++#endif // WASM_WASI
+ 			sock->socket = SOCK_ERR;
+ 		}
+ 
+@@ -254,7 +256,11 @@ static inline int sock_sendto(php_netstream_data_t *sock, const char *buf, size_
+ {
+ 	int ret;
+ 	if (addr) {
++#ifndef WASM_WASI
+ 		ret = sendto(sock->socket, buf, XP_SOCK_BUF_SIZE(buflen), flags, addr, XP_SOCK_BUF_SIZE(addrlen));
++#else
++		ret = 0;
++#endif // WASM_WASI
+ 
+ 		return (ret == SOCK_CONN_ERR) ? -1 : ret;
+ 	}
+@@ -276,7 +282,11 @@ static inline int sock_recvfrom(php_netstream_data_t *sock, char *buf, size_t bu
+ 	if (want_addr) {
+ 		php_sockaddr_storage sa;
+ 		socklen_t sl = sizeof(sa);
++#ifndef WASM_WASI
+ 		ret = recvfrom(sock->socket, buf, XP_SOCK_BUF_SIZE(buflen), flags, (struct sockaddr*)&sa, &sl);
++#else
++		ret = 0;
++#endif
+ 		ret = (ret == SOCK_CONN_ERR) ? -1 : ret;
+ #ifdef PHP_WIN32
+ 		/* POSIX discards excess bytes without signalling failure; emulate this on Windows */
+@@ -335,6 +345,7 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 
+ 				if (sock->socket == -1) {
+ 					alive = 0;
++#ifndef WASM_WASI
+ 				} else if (php_pollfd_for(sock->socket, PHP_POLLREADABLE|POLLPRI, &tv) > 0) {
+ #ifdef PHP_WIN32
+ 					int ret;
+@@ -349,6 +360,7 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 						(0 > ret && err != EWOULDBLOCK && err != EAGAIN && err != EMSGSIZE)) { /* there was an unrecoverable error */
+ 						alive = 0;
+ 					}
++#endif // WASM_WASI
+ 				}
+ 				return alive ? PHP_STREAM_OPTION_RETURN_OK : PHP_STREAM_OPTION_RETURN_ERR;
+ 			}
+@@ -377,7 +389,11 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 
+ 			switch (xparam->op) {
+ 				case STREAM_XPORT_OP_LISTEN:
++#ifndef WASM_WASI
+ 					xparam->outputs.returncode = (listen(sock->socket, xparam->inputs.backlog) == 0) ?  0: -1;
++#else
++					xparam->outputs.returncode = 0;
++#endif // WASM_WASI
+ 					return PHP_STREAM_OPTION_RETURN_OK;
+ 
+ 				case STREAM_XPORT_OP_GET_NAME:
+@@ -399,7 +415,9 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 				case STREAM_XPORT_OP_SEND:
+ 					flags = 0;
+ 					if ((xparam->inputs.flags & STREAM_OOB) == STREAM_OOB) {
++#ifndef WASM_WASI
+ 						flags |= MSG_OOB;
++#endif // WASM_WASI
+ 					}
+ 					xparam->outputs.returncode = sock_sendto(sock,
+ 							xparam->inputs.buf, xparam->inputs.buflen,
+@@ -417,10 +435,14 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 				case STREAM_XPORT_OP_RECV:
+ 					flags = 0;
+ 					if ((xparam->inputs.flags & STREAM_OOB) == STREAM_OOB) {
++#ifndef WASM_WASI
+ 						flags |= MSG_OOB;
++#endif // WASM_WASI
+ 					}
+ 					if ((xparam->inputs.flags & STREAM_PEEK) == STREAM_PEEK) {
++#ifndef WASM_WASI
+ 						flags |= MSG_PEEK;
++#endif // WASM_WASI
+ 					}
+ 					xparam->outputs.returncode = sock_recvfrom(sock,
+ 							xparam->inputs.buf, xparam->inputs.buflen,
+@@ -555,6 +577,7 @@ static inline int parse_unix_address(php_stream_xport_param *xparam, struct sock
+ 	memset(unix_addr, 0, sizeof(*unix_addr));
+ 	unix_addr->sun_family = AF_UNIX;
+ 
++#ifndef WASM_WASI
+ 	/* we need to be binary safe on systems that support an abstract
+ 	 * namespace */
+ 	if (xparam->inputs.namelen >= sizeof(unix_addr->sun_path)) {
+@@ -570,6 +593,7 @@ static inline int parse_unix_address(php_stream_xport_param *xparam, struct sock
+ 	}
+ 
+ 	memcpy(unix_addr->sun_path, xparam->inputs.name, xparam->inputs.namelen);
++#endif // WASM_WASI
+ 
+ 	return 1;
+ }
+@@ -631,8 +655,9 @@ static inline int php_tcp_sockop_bind(php_stream *stream, php_netstream_data_t *
+ 	if (stream->ops == &php_stream_unix_socket_ops || stream->ops == &php_stream_unixdg_socket_ops) {
+ 		struct sockaddr_un unix_addr;
+ 
++#ifndef WASM_WASI
+ 		sock->socket = socket(PF_UNIX, stream->ops == &php_stream_unix_socket_ops ? SOCK_STREAM : SOCK_DGRAM, 0);
+-
++#endif // WASM_WASI
+ 		if (sock->socket == SOCK_ERR) {
+ 			if (xparam->want_errortext) {
+ 				xparam->outputs.error_text = strpprintf(0, "Failed to create unix%s socket %s",
+@@ -644,8 +669,12 @@ static inline int php_tcp_sockop_bind(php_stream *stream, php_netstream_data_t *
+ 
+ 		parse_unix_address(xparam, &unix_addr);
+ 
++#ifndef WASM_WASI
+ 		return bind(sock->socket, (const struct sockaddr *)&unix_addr,
+ 			(socklen_t) XtOffsetOf(struct sockaddr_un, sun_path) + xparam->inputs.namelen);
++#else
++		return 0;
++#endif // WASM_WASI
+ 	}
+ #endif
+ 
+@@ -712,7 +741,9 @@ static inline int php_tcp_sockop_connect(php_stream *stream, php_netstream_data_
+ 	if (stream->ops == &php_stream_unix_socket_ops || stream->ops == &php_stream_unixdg_socket_ops) {
+ 		struct sockaddr_un unix_addr;
+ 
++#ifndef WASM_WASI
+ 		sock->socket = socket(PF_UNIX, stream->ops == &php_stream_unix_socket_ops ? SOCK_STREAM : SOCK_DGRAM, 0);
++#endif // WASM_WASI
+ 
+ 		if (sock->socket == SOCK_ERR) {
+ 			if (xparam->want_errortext) {
+@@ -724,7 +755,11 @@ static inline int php_tcp_sockop_connect(php_stream *stream, php_netstream_data_
+ 		parse_unix_address(xparam, &unix_addr);
+ 
+ 		ret = php_network_connect_socket(sock->socket,
++#ifndef WASM_WASI
+ 				(const struct sockaddr *)&unix_addr, (socklen_t) XtOffsetOf(struct sockaddr_un, sun_path) + xparam->inputs.namelen,
++#else
++				(const struct sockaddr *)&unix_addr, xparam->inputs.namelen,
++#endif // WASM_WASI
+ 				xparam->op == STREAM_XPORT_OP_CONNECT_ASYNC, xparam->inputs.timeout,
+ 				xparam->want_errortext ? &xparam->outputs.error_text : NULL,
+ 				&err);
+diff --git a/sapi/cgi/cgi_main.c b/sapi/cgi/cgi_main.c
+index a36f426d26..8a64f49656 100644
+--- a/sapi/cgi/cgi_main.c
++++ b/sapi/cgi/cgi_main.c
+@@ -45,7 +45,9 @@
+ # include <unistd.h>
+ #endif
+ 
++#ifndef WASM_WASI
+ #include <signal.h>
++#endif
+ 
+ #include <locale.h>
+ 
+@@ -94,10 +96,12 @@ int __riscosify_control = __RISCOSIFY_STRICT_UNIX_SPECS;
+ # include "valgrind/callgrind.h"
+ #endif
+ 
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ /* XXX this will need to change later when threaded fastcgi is implemented.  shane */
+ struct sigaction act, old_term, old_quit, old_int;
+ #endif
++#endif // WASM_WASI
+ 
+ static void (*php_php_import_environment_variables)(zval *array_ptr);
+ 
+@@ -1471,6 +1475,7 @@ static void init_request_info(fcgi_request *request)
+  */
+ void fastcgi_cleanup(int signal)
+ {
++#ifndef WASM_WASI
+ #ifdef DEBUG_FASTCGI
+ 	fprintf(stderr, "FastCGI shutdown, pid %d\n", getpid());
+ #endif
+@@ -1485,6 +1490,9 @@ void fastcgi_cleanup(int signal)
+ 	} else {
+ 		exit(0);
+ 	}
++#else
++	exit(0);
++#endif // WASM_WASI
+ }
+ #else
+ BOOL WINAPI fastcgi_cleanup(DWORD sig)
+@@ -1796,7 +1804,9 @@ int main(int argc, char *argv[])
+ # endif
+ #endif
+ 
++#ifndef WASM_WASI
+ 	zend_signal_startup();
++#endif // WASM_WASI
+ 
+ #ifdef ZTS
+ 	ts_allocate_id(&php_cgi_globals_id, sizeof(php_cgi_globals_struct), (ts_allocate_ctor) php_cgi_globals_ctor, NULL);
+@@ -1926,6 +1936,7 @@ int main(int argc, char *argv[])
+ 		return FAILURE;
+ 	}
+ 
++#ifndef WASM_WASI
+ 	/* check force_cgi after startup, so we have proper output */
+ 	if (cgi && CGIG(force_redirect)) {
+ 		/* Apache will generate REDIRECT_STATUS,
+@@ -1966,6 +1977,7 @@ consult the installation file that came with this distribution, or visit \n\
+ 			return FAILURE;
+ 		}
+ 	}
++#endif // WASM_WASI
+ 
+ #ifndef HAVE_ATTRIBUTE_WEAK
+ 	fcgi_set_logger(fcgi_log);
+@@ -2042,12 +2054,17 @@ consult the installation file that came with this distribution, or visit \n\
+ 			pid_t pid;
+ 
+ 			/* Create a process group for ourself & children */
++#ifndef WASM_WASI
+ 			setsid();
+ 			pgroup = getpgrp();
++#else
++			pgroup = 0;
++#endif // WASM_WASI
+ #ifdef DEBUG_FASTCGI
+ 			fprintf(stderr, "Process group %d\n", pgroup);
+ #endif
+ 
++#ifndef WASM_WASI
+ 			/* Set up handler to kill children upon exit */
+ 			act.sa_flags = 0;
+ 			act.sa_handler = fastcgi_cleanup;
+@@ -2058,6 +2075,7 @@ consult the installation file that came with this distribution, or visit \n\
+ 				perror("Can't set signals");
+ 				exit(1);
+ 			}
++#endif // WASM_WASI
+ 
+ 			if (fcgi_in_shutdown()) {
+ 				goto parent_out;
+@@ -2068,7 +2086,11 @@ consult the installation file that came with this distribution, or visit \n\
+ #ifdef DEBUG_FASTCGI
+ 					fprintf(stderr, "Forking, %d running\n", running);
+ #endif
++#ifndef WASM_WASI
+ 					pid = fork();
++#else
++					pid = 1;
++#endif // WASM_WASI
+ 					switch (pid) {
+ 					case 0:
+ 						/* One of the children.
+@@ -2077,11 +2099,13 @@ consult the installation file that came with this distribution, or visit \n\
+ 						 */
+ 						parent = 0;
+ 
++#ifndef WASM_WASI
+ 						/* don't catch our signals */
+ 						sigaction(SIGTERM, &old_term, 0);
+ 						sigaction(SIGQUIT, &old_quit, 0);
+ 						sigaction(SIGINT,  &old_int,  0);
+ 						zend_signal_init();
++#endif // WASM_WASI
+ 						break;
+ 					case -1:
+ 						perror("php (pre-forking)");
+@@ -2100,12 +2124,14 @@ consult the installation file that came with this distribution, or visit \n\
+ #endif
+ 					parent_waiting = 1;
+ 					while (1) {
++#ifndef WASM_WASI
+ 						if (wait(&status) >= 0) {
+ 							running--;
+ 							break;
+ 						} else if (exit_signal) {
+ 							break;
+ 						}
++#endif // WASM_WASI
+ 					}
+ 					if (exit_signal) {
+ #if 0
+diff --git a/sapi/fpm/fpm/fpm_unix.c b/sapi/fpm/fpm/fpm_unix.c
+index d0be0bfea2..4fc3113336 100644
+--- a/sapi/fpm/fpm/fpm_unix.c
++++ b/sapi/fpm/fpm/fpm_unix.c
+@@ -9,7 +9,9 @@
+ #include <unistd.h>
+ #include <sys/types.h>
+ #include <pwd.h>
+-#include <grp.h>
++#ifndef WASM_WASI
++#  include <grp.h>
++#endif // WASM_WASI
+ 
+ #ifdef HAVE_PRCTL
+ #include <sys/prctl.h>
+diff --git a/sapi/litespeed/lsapilib.c b/sapi/litespeed/lsapilib.c
+index 3dbf8bc2fa..3fa2a79a9e 100644
+--- a/sapi/litespeed/lsapilib.c
++++ b/sapi/litespeed/lsapilib.c
+@@ -67,7 +67,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <sys/time.h>
+ #include <sys/uio.h>
+ #include <sys/wait.h>
+-#include <grp.h>
++#ifndef WASM_WASI
++#  include <grp.h>
++#endif // WASM_WASI
+ #include <pwd.h>
+ #include <time.h>
+ #include <unistd.h>
+diff --git a/wasmlabs-build.sh b/wasmlabs-build.sh
+new file mode 100755
+index 0000000000..e08c362a33
+--- /dev/null
++++ b/wasmlabs-build.sh
+@@ -0,0 +1,71 @@
++#!/bin/bash
++
++if [[ ! -v WASI_SDK_ROOT ]]
++then
++    echo "Please set WASI_SDK_ROOT and run again"
++    exit 1
++fi
++
++if [[ ! -v WASMLABS_BUILD_OUTPUT ]]
++then
++    echo "Assuming $PWD/wasmlabs-build-output as WASMLABS_BUILD_OUTPUT"
++    export WASMLABS_BUILD_OUTPUT=$PWD/wasmlabs-build-output
++fi
++
++function onExit {
++    echo "=============================================================="
++    echo "Build progress logs:"
++    cat wasmlabs-progress.log
++}
++trap onExit EXIT
++
++echo "$(date --iso-8601=ns) | Using WASI_SDK_ROOT=$WASI_SDK_ROOT " > wasmlabs-progress.log
++
++function logStatus {
++    echo "$(date --iso-8601=ns) | $@" >> wasmlabs-progress.log
++}
++
++export WASI_SYSROOT="${WASI_SDK_ROOT}/share/wasi-sysroot"
++
++export CC=${WASI_SDK_ROOT}/bin/clang
++export LD=${WASI_SDK_ROOT}/bin/wasm-ld
++export CXX=${WASI_SDK_ROOT}/bin/clang++
++export NM=${WASI_SDK_ROOT}/bin/llvm-nm
++export AR=${WASI_SDK_ROOT}/bin/llvm-ar
++export RANLIB=${WASI_SDK_ROOT}/bin/llvm-ranlib
++
++# export CFLAGS_CONFIG="-O3 -g"
++export CFLAGS_CONFIG="-O2"
++
++export CFLAGS_WASI="--sysroot=${WASI_SYSROOT} -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS"
++export LDFLAGS_WASI="--sysroot=${WASI_SYSROOT} -lwasi-emulated-mman -lwasi-emulated-getpid -lwasi-emulated-signal -lwasi-emulated-process-clocks"
++
++export CFLAGS_SQLITE='-DSQLITE_OMIT_LOAD_EXTENSION=1'
++export LDFLAGS_SQLITE='-lsqlite3'
++
++export CFLAGS_LIBS="-I$WASMLABS_BUILD_OUTPUT/include"
++export LDFLAGS_LIBS="-L$WASMLABS_BUILD_OUTPUT/lib"
++
++export CFLAGS_PHP='-D_POSIX_SOURCE=1 -D_GNU_SOURCE=1 -DHAVE_FORK=0 -DWASM_WASI'
++
++# We need to add LDFLAGS ot CFLAGS because autoconf compiles(+links) to binary when checking stuff
++export LDFLAGS="$LDFLAGS_WASI $LDFLAGS_LIBS $LDFLAGS_SQLITE"
++export CFLAGS="$CFLAGS_CONFIG $CFLAGS_WASI $CFLAGS_SQLITE $CFLAGS_LIBS $CFLAGS_PHP $LDFLAGS"
++
++logStatus "Generating configure script... "
++./buildconf --force
++
++export PHP_CONFIGURE=' --without-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite'
++
++logStatus "Configuring build with '$PHP_CONFIGURE'... "
++./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi $PHP_CONFIGURE
++
++logStatus "Building php-cgi... "
++make cgi
++
++logStatus "Preparing artifacts... "
++mkdir -p $WASMLABS_BUILD_OUTPUT/bin 2>/dev/null
++
++cp sapi/cgi/php-cgi $WASMLABS_BUILD_OUTPUT/bin/
++
++logStatus "DONE. Artifacts in $WASMLABS_BUILD_OUTPUT"

--- a/php/patches/7.4.32/patch.v1.diff
+++ b/php/patches/7.4.32/patch.v1.diff
@@ -1,3 +1,13 @@
+diff --git a/.gitignore b/.gitignore
+index cd6e779831..8d8493ec04 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -281,3 +281,5 @@ tmp-php.ini
+ !/ext/fileinfo/magicdata.patch
+ !/ext/pcre/pcre2lib/config.h
+ !/win32/build/Makefile
++
++/wasmlabs-output/
 diff --git a/Zend/zend.c b/Zend/zend.c
 index b667514020..bf72cce272 100644
 --- a/Zend/zend.c
@@ -60,29 +70,76 @@ index 94fd9a3559..75bea56935 100644
  int zend_startup(zend_utility_functions *utility_functions);
  void zend_shutdown(void);
 diff --git a/Zend/zend_alloc.c b/Zend/zend_alloc.c
-index 3a33e5441c..46e97a30fa 100644
+index 3a33e5441c..014801a99c 100644
 --- a/Zend/zend_alloc.c
 +++ b/Zend/zend_alloc.c
-@@ -670,7 +670,9 @@ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
- 	} else if (ZEND_MM_ALIGNED_OFFSET(ptr, alignment) == 0) {
- #ifdef MADV_HUGEPAGE
- 		if (zend_mm_use_huge_pages) {
-+#ifndef WASM_WASI
- 			madvise(ptr, size, MADV_HUGEPAGE);
-+#endif // WASM_WASI
- 		}
+@@ -79,7 +79,7 @@
+ #include <fcntl.h>
+ #include <errno.h>
+ 
+-#ifndef _WIN32
++#if !defined(_WIN32) && HAVE_MMAP
+ # include <sys/mman.h>
+ # ifndef MAP_ANON
+ #  ifdef MAP_ANONYMOUS
+@@ -420,6 +420,8 @@ static void *zend_mm_mmap_fixed(void *addr, size_t size)
+ {
+ #ifdef _WIN32
+ 	return VirtualAlloc(addr, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
++#elif ! HAVE_MMAP
++	return NULL;
+ #else
+ 	int flags = MAP_PRIVATE | MAP_ANON;
+ #if defined(MAP_EXCL)
+@@ -458,6 +460,10 @@ static void *zend_mm_mmap(size_t size)
+ 		return NULL;
+ 	}
+ 	return ptr;
++#elif ! HAVE_MMAP
++	void* ptr = malloc(size);
++	memset(ptr, 0, size);
++	return ptr;
+ #else
+ 	void *ptr;
+ 
+@@ -490,6 +496,8 @@ static void zend_mm_munmap(void *addr, size_t size)
+ 		stderr_last_error("VirtualFree() failed");
+ #endif
+ 	}
++#elif ! HAVE_MMAP
++	free(addr);
+ #else
+ 	if (munmap(addr, size) != 0) {
+ #if ZEND_MM_ERROR
+@@ -663,6 +671,11 @@ static zend_always_inline int zend_mm_bitset_is_free_range(zend_mm_bitset *bitse
+ 
+ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
+ {
++#if ! HAVE_MMAP
++	void* ptr = aligned_alloc(alignment, size);
++	memset(ptr, 0, size);
++	return ptr;
++#else
+ 	void *ptr = zend_mm_mmap(size);
+ 
+ 	if (ptr == NULL) {
+@@ -709,6 +722,7 @@ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
  #endif
  		return ptr;
-@@ -703,7 +705,9 @@ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
- 		}
- # ifdef MADV_HUGEPAGE
- 		if (zend_mm_use_huge_pages) {
-+#ifndef WASM_WASI
- 			madvise(ptr, size, MADV_HUGEPAGE);
-+#endif // WASM_WASI
- 		}
- # endif
+ 	}
++#endif
+ }
+ 
+ static void *zend_mm_chunk_alloc(zend_mm_heap *heap, size_t size, size_t alignment)
+@@ -2786,7 +2800,7 @@ ZEND_API void start_memory_manager(void)
+ #else
+ 	alloc_globals_ctor(&alloc_globals);
  #endif
+-#ifndef _WIN32
++#if !defined(_WIN32) && HAVE_MMAP
+ #  if defined(_SC_PAGESIZE)
+ 	REAL_PAGE_SIZE = sysconf(_SC_PAGESIZE);
+ #  elif defined(_SC_PAGE_SIZE)
 diff --git a/Zend/zend_globals.h b/Zend/zend_globals.h
 index 2e9fff40ad..e95771ef42 100644
 --- a/Zend/zend_globals.h
@@ -198,25 +255,25 @@ index e2a2b8ff9c..c5c4bc39f1 100644
  		char *ptr = mktemp(buf);
  		tfd = open(ptr, O_RDWR|O_TRUNC|O_EXCL|O_CREAT, 0600);
 diff --git a/ext/fileinfo/libmagic/fsmagic.c b/ext/fileinfo/libmagic/fsmagic.c
-index 938b526a37..4335b5b0da 100644
+index 938b526a37..3fd4e57474 100644
 --- a/ext/fileinfo/libmagic/fsmagic.c
 +++ b/ext/fileinfo/libmagic/fsmagic.c
-@@ -199,6 +199,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, zend_stat_t *sb)
- 	return 1;
+@@ -167,6 +167,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, zend_stat_t *sb)
+ # endif
  #endif
  
 +#ifndef WASM_WASI
- #ifdef	S_IFSOCK
- #ifndef __COHERENT__
- 	case S_IFSOCK:
-@@ -211,6 +212,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, zend_stat_t *sb)
+ #ifdef	S_IFIFO
+ 	case S_IFIFO:
+ 		if((ms->flags & MAGIC_DEVICES) != 0)
+@@ -179,6 +180,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, zend_stat_t *sb)
+ 			return -1;
  		break;
  #endif
- #endif
 +#endif // WASM_WASI
- 	case S_IFREG:
- 		/*
- 		 * regular file, check next possibility
+ #ifdef	S_IFDOOR
+ 	case S_IFDOOR:
+ 		if (mime) {
 diff --git a/ext/pdo_sqlite/sqlite_statement.c b/ext/pdo_sqlite/sqlite_statement.c
 index a8723da640..ae48e3be3d 100644
 --- a/ext/pdo_sqlite/sqlite_statement.c
@@ -757,7 +814,7 @@ index 3bd3421603..bc23639afd 100644
  /* }}} */
  
 diff --git a/ext/standard/filestat.c b/ext/standard/filestat.c
-index be6b2dda09..97c99ad008 100644
+index be6b2dda09..1a1ca5e06e 100644
 --- a/ext/standard/filestat.c
 +++ b/ext/standard/filestat.c
 @@ -64,7 +64,9 @@
@@ -870,18 +927,16 @@ index be6b2dda09..97c99ad008 100644
  
  	switch (type) {
  	case FS_PERMS:
-@@ -900,9 +920,11 @@ PHPAPI void php_stat(const char *filename, size_t filename_length, int type, zva
+@@ -895,7 +915,9 @@ PHPAPI void php_stat(const char *filename, size_t filename_length, int type, zva
+ 			RETURN_STRING("link");
+ 		}
+ 		switch(ssb.sb.st_mode & S_IFMT) {
++#ifndef WASM_WASI
+ 		case S_IFIFO: RETURN_STRING("fifo");
++#endif // WASM_WASI
+ 		case S_IFCHR: RETURN_STRING("char");
  		case S_IFDIR: RETURN_STRING("dir");
  		case S_IFBLK: RETURN_STRING("block");
- 		case S_IFREG: RETURN_STRING("file");
-+#ifndef WASM_WASI
- #if defined(S_IFSOCK) && !defined(PHP_WIN32)
- 		case S_IFSOCK: RETURN_STRING("socket");
- #endif
-+#endif // WASM_WASI
- 		}
- 		php_error_docref(NULL, E_NOTICE, "Unknown file type (%d)", ssb.sb.st_mode&S_IFMT);
- 		RETURN_STRING("unknown");
 diff --git a/ext/standard/flock_compat.c b/ext/standard/flock_compat.c
 index 8bbf6fb895..b9d88f55d3 100644
 --- a/ext/standard/flock_compat.c
@@ -1950,12 +2005,103 @@ index 3dbf8bc2fa..3fa2a79a9e 100644
  #include <pwd.h>
  #include <time.h>
  #include <unistd.h>
+diff --git a/wasmlabs-README.md b/wasmlabs-README.md
+new file mode 100644
+index 0000000000..c57f0c8a3a
+--- /dev/null
++++ b/wasmlabs-README.md
+@@ -0,0 +1,85 @@
++# About
++
++This contains a non-exhaustive list of changes that we had to make to be able to build the PHP codebase for wasm32-wasi.
++
++To remove or add code for wasm32-wasi builds we are using the 'WASM_WASI' macro.
++
++# emulated functionality
++
++We are using emulation of getpid, signals and clocks.
++
++We are not using mman emulation due to the reasons outlined [below](#mmap-support).
++
++# excluded code
++
++This describes the most common places where we needed to exclude code because
++a method or constant is not available or is somehow different with WASI.
++
++## S_IFSOCK is the same as  S_IFFIFO
++
++WASI snapshot2 is not out yet - https://github.com/nodejs/uvwasi/issues/59.
++
++Thus there is no support for a FIFO filetype. So the two constants were
++defined to the same value. Because of this a switch/case on file type will fail
++due to duplicate case labels.
++
++We've commented out the S_IFFIFO cases.
++
++## setjmp and longjmp
++
++There is no such support in WASI yet.
++
++We have taken a shortcut and just botched the exception handling in the zend
++zend engine. The program will just ignore exceptions as they happen.
++
++## sqlite3 support
++
++We are using sqlite 3.39.2 instead of the original 3.28.0 that goes with php 7.3.33.
++
++Additionally sqlite3 had to be modified in some ways for WASM_WASI builds:
++
++ - mark fchmod, fchown as not defined
++ - use "dotlockIoFinder" for file locking
++ - skip sqlite3_finalize
++
++## unsupported posix methods
++
++We have stubbed the posix methods in `ext/posix/posix.c` which are not supported for WASI.
++
++Other methods, which are direcly used without wrapping were skipped in place by stubbing
++the method that is calling them.
++
++## php flock
++
++File locking is also stubbed and always returns success.
++
++## mmap support
++
++**TL;DR:** 
++
++We are building without MMAP support. To make it work, changes had to be made to zend_alloc.c resulting in a slower but correct behavior.
++
++
++**Details:** 
++
++Take a look [here](https://linux.die.net/man/2/mmap) for the docs for mmap and munmap
++
++The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-16 tag).
++
++ - mmap uses malloc to reserve the necessary amount of memory (always ignoring the addr hint)
++ - mmap zeroes out bytes if MAP_ANONYMOUS is used
++ - mmap reads file contents if mapping an fd
++ - munmap only supports unmapping of the exact same chunk (addr + size) that was previously mapped - as it is effectively a free of the malloc-ed memory
++
++In the php code there are two places where mman.h is used
++
++1. In zend_alloc.c - for custom memory allocation
++
++ - there is code that relies on partial munmap (for the sake of proper alignment at higher level). Using the emulated mmap will lead to leaks here, as munmap fails.
++ - there is code that relies on the capability to extend a mmaped chunk - this will fail and lead to performance degradation (falling-back to reallocation)
++
++2. In plain_wrapper.c and zend_stream.c - for reading of the interpreted .php source files
++
++ - the tricky thing here is the ZEND_MMAP_AHEAD needed by the zend_language_scanner. The language parser depends on having a bunch of null-terminating characters at the end of the interpreted string. The usual mmap behavior guarantees that when files are mmaped memory is reserved in pages of size `sysconf(_SC_PAGE_SIZE)`, which is padded with `\0`-s after the file contents. However, the emulated mmap does not do that (as it only malloc-s what was requested). This leads to the parser reading random stuff from memory after the mmaped file contents. 
++
++
 diff --git a/wasmlabs-build.sh b/wasmlabs-build.sh
 new file mode 100755
-index 0000000000..e08c362a33
+index 0000000000..a4b4da9687
 --- /dev/null
 +++ b/wasmlabs-build.sh
-@@ -0,0 +1,71 @@
+@@ -0,0 +1,72 @@
 +#!/bin/bash
 +
 +if [[ ! -v WASI_SDK_ROOT ]]
@@ -1966,21 +2112,22 @@ index 0000000000..e08c362a33
 +
 +if [[ ! -v WASMLABS_BUILD_OUTPUT ]]
 +then
-+    echo "Assuming $PWD/wasmlabs-build-output as WASMLABS_BUILD_OUTPUT"
-+    export WASMLABS_BUILD_OUTPUT=$PWD/wasmlabs-build-output
++    echo "Assuming $PWD/wasmlabs-output as WASMLABS_BUILD_OUTPUT"
++    export WASMLABS_BUILD_OUTPUT=$PWD/wasmlabs-output
++    mkdir $WASMLABS_BUILD_OUTPUT 2>&1 >/dev/null
 +fi
 +
 +function onExit {
 +    echo "=============================================================="
 +    echo "Build progress logs:"
-+    cat wasmlabs-progress.log
++    cat $WASMLABS_BUILD_OUTPUT/wasmlabs-progress.log
 +}
 +trap onExit EXIT
 +
-+echo "$(date --iso-8601=ns) | Using WASI_SDK_ROOT=$WASI_SDK_ROOT " > wasmlabs-progress.log
++echo "$(date --iso-8601=ns) | Using WASI_SDK_ROOT=$WASI_SDK_ROOT " >  $WASMLABS_BUILD_OUTPUT/wasmlabs-progress.log
 +
 +function logStatus {
-+    echo "$(date --iso-8601=ns) | $@" >> wasmlabs-progress.log
++    echo "$(date --iso-8601=ns) | $@" >>  $WASMLABS_BUILD_OUTPUT/wasmlabs-progress.log
 +}
 +
 +export WASI_SYSROOT="${WASI_SDK_ROOT}/share/wasi-sysroot"
@@ -1995,8 +2142,8 @@ index 0000000000..e08c362a33
 +# export CFLAGS_CONFIG="-O3 -g"
 +export CFLAGS_CONFIG="-O2"
 +
-+export CFLAGS_WASI="--sysroot=${WASI_SYSROOT} -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS"
-+export LDFLAGS_WASI="--sysroot=${WASI_SYSROOT} -lwasi-emulated-mman -lwasi-emulated-getpid -lwasi-emulated-signal -lwasi-emulated-process-clocks"
++export CFLAGS_WASI="--sysroot=${WASI_SYSROOT} -D_WASI_EMULATED_GETPID -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS"
++export LDFLAGS_WASI="--sysroot=${WASI_SYSROOT} -lwasi-emulated-getpid -lwasi-emulated-signal -lwasi-emulated-process-clocks"
 +
 +export CFLAGS_SQLITE='-DSQLITE_OMIT_LOAD_EXTENSION=1'
 +export LDFLAGS_SQLITE='-lsqlite3'

--- a/php/patches/7.4.32/wasmlabs-README.md
+++ b/php/patches/7.4.32/wasmlabs-README.md
@@ -1,0 +1,85 @@
+# About
+
+This contains a non-exhaustive list of changes that we had to make to be able to build the PHP codebase for wasm32-wasi.
+
+To remove or add code for wasm32-wasi builds we are using the 'WASM_WASI' macro.
+
+# emulated functionality
+
+We are using emulation of getpid, signals and clocks.
+
+We are not using mman emulation due to the reasons outlined [below](#mmap-support).
+
+# excluded code
+
+This describes the most common places where we needed to exclude code because
+a method or constant is not available or is somehow different with WASI.
+
+## S_IFSOCK is the same as  S_IFFIFO
+
+WASI snapshot2 is not out yet - https://github.com/nodejs/uvwasi/issues/59.
+
+Thus there is no support for a FIFO filetype. So the two constants were
+defined to the same value. Because of this a switch/case on file type will fail
+due to duplicate case labels.
+
+We've commented out the S_IFFIFO cases.
+
+## setjmp and longjmp
+
+There is no such support in WASI yet.
+
+We have taken a shortcut and just botched the exception handling in the zend
+zend engine. The program will just ignore exceptions as they happen.
+
+## sqlite3 support
+
+We are using sqlite 3.39.2 instead of the original 3.28.0 that goes with php 7.3.33.
+
+Additionally sqlite3 had to be modified in some ways for WASM_WASI builds:
+
+ - mark fchmod, fchown as not defined
+ - use "dotlockIoFinder" for file locking
+ - skip sqlite3_finalize
+
+## unsupported posix methods
+
+We have stubbed the posix methods in `ext/posix/posix.c` which are not supported for WASI.
+
+Other methods, which are direcly used without wrapping were skipped in place by stubbing
+the method that is calling them.
+
+## php flock
+
+File locking is also stubbed and always returns success.
+
+## mmap support
+
+**TL;DR:** 
+
+We are building without MMAP support. To make it work, changes had to be made to zend_alloc.c resulting in a slower but correct behavior.
+
+
+**Details:** 
+
+Take a look [here](https://linux.die.net/man/2/mmap) for the docs for mmap and munmap
+
+The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-16 tag).
+
+ - mmap uses malloc to reserve the necessary amount of memory (always ignoring the addr hint)
+ - mmap zeroes out bytes if MAP_ANONYMOUS is used
+ - mmap reads file contents if mapping an fd
+ - munmap only supports unmapping of the exact same chunk (addr + size) that was previously mapped - as it is effectively a free of the malloc-ed memory
+
+In the php code there are two places where mman.h is used
+
+1. In zend_alloc.c - for custom memory allocation
+
+ - there is code that relies on partial munmap (for the sake of proper alignment at higher level). Using the emulated mmap will lead to leaks here, as munmap fails.
+ - there is code that relies on the capability to extend a mmaped chunk - this will fail and lead to performance degradation (falling-back to reallocation)
+
+2. In plain_wrapper.c and zend_stream.c - for reading of the interpreted .php source files
+
+ - the tricky thing here is the ZEND_MMAP_AHEAD needed by the zend_language_scanner. The language parser depends on having a bunch of null-terminating characters at the end of the interpreted string. The usual mmap behavior guarantees that when files are mmaped memory is reserved in pages of size `sysconf(_SC_PAGE_SIZE)`, which is padded with `\0`-s after the file contents. However, the emulated mmap does not do that (as it only malloc-s what was requested). This leads to the parser reading random stuff from memory after the mmaped file contents. 
+
+


### PR DESCRIPTION
1. This is the initial version of the 7.4.32 patch. We still need to debug why it cannot handle WP
2. Add scripts for reproducible builds.