### PR TITLE
chore: update pipelines

### DIFF
--- a/.github/workflows/build-php.yaml
+++ b/.github/workflows/build-php.yaml
@@ -19,8 +19,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Build PHP
         run: make php/php-${{ matrix.version }}
+      - name: Rename artifacts
+        shell: bash
+        run: |
+          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{,-${{ matrix.version }}.wasm}
       - name: Upload php-cgi-${{ matrix.version }}.wasm artifact
         uses: actions/upload-artifact@v3
         with:
           name: php-cgi-${{ matrix.version }}.wasm
-          path: php/build-output/php/php-${{ matrix.version }}/bin/php-cgi
+          path: php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}.wasm

--- a/.github/workflows/release-php.yaml
+++ b/.github/workflows/release-php.yaml
@@ -1,3 +1,9 @@
+# Note that for this workflow to be triggered, the tag needs to be
+# created of the form `php/<version>+<buildinfo>`, where <buildinfo>
+# by convention is YYYYMMDD-<short-sha> (short SHA can be calculated
+# with `git rev-parse --short HEAD`). An example of a tag following
+# the convention that triggers automation would be
+# `php/7.3.33+20221123-8dfe8b9`.
 name: Release PHP
 on:
   push:
@@ -17,21 +23,21 @@ jobs:
         #
         # This if could be moved to the parent `job` section when it's
         # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: github.event.ref == format('refs/tags/php/{0}', matrix.version)
+        if: startsWith(github.event.ref,  format('refs/tags/php/{0}+', matrix.version))
         uses: actions/checkout@v3
       - name: Build PHP
         # Only run for the PHP version specified in the git tag.
         #
         # This if could be moved to the parent `job` section when it's
         # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: github.event.ref == format('refs/tags/php/{0}', matrix.version)
+        if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         run: make php/php-${{ matrix.version }}
       - name: Rename release artifacts
         # Only run for the PHP version specified in the git tag.
         #
         # This if could be moved to the parent `job` section when it's
         # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: github.event.ref == format('refs/tags/php/{0}', matrix.version)
+        if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         shell: bash
         run: |
           sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{,.wasm}
@@ -40,7 +46,7 @@ jobs:
         #
         # This if could be moved to the parent `job` section when it's
         # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: github.event.ref == format('refs/tags/php/{0}', matrix.version)
+        if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         shell: bash
         run: |
           wget https://github.com/WebAssembly/binaryen/releases/download/version_${{ env.BINARYEN_VERSION }}/binaryen-version_${{ env.BINARYEN_VERSION }}-x86_64-linux.tar.gz
@@ -51,7 +57,7 @@ jobs:
         #
         # This if could be moved to the parent `job` section when it's
         # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: github.event.ref == format('refs/tags/php/{0}', matrix.version)
+        if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         shell: bash
         run: |
           sudo /opt/bin/wasm-opt -Os -o php/build-output/php/php-${{ matrix.version }}/bin/php-cgi.size-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-cgi.wasm
@@ -61,7 +67,7 @@ jobs:
         #
         # This if could be moved to the parent `job` section when it's
         # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: github.event.ref == format('refs/tags/php/{0}', matrix.version)
+        if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         run: |
           sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{,-${{ matrix.version }}}.wasm
           sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{,-${{ matrix.version }}}.size-optimized.wasm
@@ -71,7 +77,7 @@ jobs:
         #
         # This if could be moved to the parent `job` section when it's
         # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: github.event.ref == format('refs/tags/php/{0}', matrix.version)
+        if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         uses: softprops/action-gh-release@v1
         with:
           files: |

--- a/README.md
+++ b/README.md
@@ -139,9 +139,11 @@ git commit -m "Add support to build php version 7.3.33"
 In order to perform a release, push a tag of the following form
 depending on the project artifacts you want to be built and published:
 
-- `php/version`, where version can be any of:
+- `php/<version>+YYYYMMDD-<short-sha>`, where version can be any of:
     - `7.3.33`
     - `7.4.32`
+
+An example of a tag following the convention that triggers automation would be `php/7.3.33+20221123-8dfe8b9`.
 
 When the tag is pushed to the repository, a GitHub release will be
 created automatically, and relevant artifacts will be automatically


### PR DESCRIPTION
- In PHP build pipelines, use `.wasm` as the suffix for the artifacts uploaded to the workflow run.

- In PHP release pipelines, enforce the need for tagging with metadata information. By convention and as an example with PHP, `php/7.3.33+20221123-8dfe8b9` would tag the release pipeline, create a GitHub release, produce the required artifacts and upload them to the release.