### PR TITLE
feature: Add php/wasmedge-php-7.4.32 Makefile target

### DIFF
--- a/.github/workflows/build-php.yaml
+++ b/.github/workflows/build-php.yaml
@@ -12,19 +12,47 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [7.3.33, 7.4.32]
+        # TODO (ereslibre): the PHP cli is conditionally compiled
+        # because it has the ability to open a listening socket-- only
+        # supported on wasmedge --. Remove build-php-cli from here and
+        # make the PHP CLI conditionally compile local server code out
+        # on all versions.
+        include:
+          - name: wasmedge-php
+            suffix: -wasmedge
+            build-php-cli: true
+            version: 7.4.32
+          - name: php
+            suffix: ""
+            build-php-cli: false
+            version: 7.3.33
+          - name: php
+            suffix: ""
+            build-php-cli: false
+            version: 7.4.32
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Build PHP
-        run: make php/php-${{ matrix.version }}
+        run: make php/${{ matrix.name }}-${{ matrix.version }}
       - name: Rename artifacts
         shell: bash
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{,-${{ matrix.version }}.wasm}
-      - name: Upload php-cgi-${{ matrix.version }}.wasm artifact
+          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}.wasm}
+      - name: Rename artifacts
+        shell: bash
+        if: ${{ matrix.build-php-cli }}
+        run: |
+          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}.wasm}
+      - name: Upload php-${{ matrix.version }}${{ matrix.suffix }}.wasm artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.build-php-cli }}
+        with:
+          name: php-${{ matrix.version }}${{ matrix.suffix }}.wasm
+          path: php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.wasm
+      - name: Upload php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm artifact
         uses: actions/upload-artifact@v3
         with:
-          name: php-cgi-${{ matrix.version }}.wasm
-          path: php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}.wasm
+          name: php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm
+          path: php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm

--- a/.github/workflows/release-php.yaml
+++ b/.github/workflows/release-php.yaml
@@ -13,10 +13,27 @@ jobs:
   release-php:
     strategy:
       matrix:
-        version: [7.3.33, 7.4.32]
+        # TODO (ereslibre): the PHP cli is conditionally compiled
+        # because it has the ability to open a listening socket-- only
+        # supported on wasmedge --. Remove build-php-cli from here and
+        # make the PHP CLI conditionally compile local server code out
+        # on all versions.
+        include:
+          - name: wasmedge-php
+            suffix: -wasmedge
+            build-php-cli: true
+            version: 7.4.32
+          - name: php
+            suffix: ""
+            build-php-cli: false
+            version: 7.3.33
+          - name: php
+            suffix: ""
+            build-php-cli: false
+            version: 7.4.32
     runs-on: ubuntu-latest
     env:
-      BINARYEN_VERSION: 110
+      BINARYEN_VERSION: 111
     steps:
       - name: Checkout repository
         # Only run for the PHP version specified in the git tag.
@@ -31,7 +48,7 @@ jobs:
         # This if could be moved to the parent `job` section when it's
         # supported by GitHub (https://github.com/community/community/discussions/37883)
         if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
-        run: make php/php-${{ matrix.version }}
+        run: make php/${{ matrix.name }}-${{ matrix.version }}
       - name: Rename release artifacts
         # Only run for the PHP version specified in the git tag.
         #
@@ -40,7 +57,16 @@ jobs:
         if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         shell: bash
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{,.wasm}
+          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}.wasm}
+      - name: Rename release artifacts
+        # Only run for the PHP version specified in the git tag.
+        #
+        # This if could be moved to the parent `job` section when it's
+        # supported by GitHub (https://github.com/community/community/discussions/37883)
+        if: ${{ startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version)) && matrix.build-php-cli }}
+        shell: bash
+        run: |
+          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}.wasm}
       - name: Setup binaryen
         # Only run for the PHP version specified in the git tag.
         #
@@ -52,7 +78,7 @@ jobs:
           wget https://github.com/WebAssembly/binaryen/releases/download/version_${{ env.BINARYEN_VERSION }}/binaryen-version_${{ env.BINARYEN_VERSION }}-x86_64-linux.tar.gz
           tar -xf binaryen-version_${{ env.BINARYEN_VERSION }}-x86_64-linux.tar.gz --strip-components=1 -C /opt
           rm binaryen-version_${{ env.BINARYEN_VERSION }}-x86_64-linux.tar.gz
-      - name: Optimize release artifacts
+      - name: Optimize php-cgi release artifacts
         # Only run for the PHP version specified in the git tag.
         #
         # This if could be moved to the parent `job` section when it's
@@ -60,19 +86,19 @@ jobs:
         if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         shell: bash
         run: |
-          sudo /opt/bin/wasm-opt -Os -o php/build-output/php/php-${{ matrix.version }}/bin/php-cgi.size-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-cgi.wasm
-          sudo /opt/bin/wasm-opt -O -o php/build-output/php/php-${{ matrix.version }}/bin/php-cgi.speed-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-cgi.wasm
-      - name: Append version to release artifacts
+          sudo /opt/bin/wasm-opt -Os -o php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.size-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm
+          sudo /opt/bin/wasm-opt -O -o php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.speed-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm
+      - name: Optimize php release artifacts
         # Only run for the PHP version specified in the git tag.
         #
         # This if could be moved to the parent `job` section when it's
         # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
+        if: ${{ startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version)) && matrix.build-php-cli }}
+        shell: bash
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{,-${{ matrix.version }}}.wasm
-          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{,-${{ matrix.version }}}.size-optimized.wasm
-          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{,-${{ matrix.version }}}.speed-optimized.wasm
-      - name: Release
+          sudo /opt/bin/wasm-opt -Os -o php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.size-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.wasm
+          sudo /opt/bin/wasm-opt -O -o php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.speed-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.wasm
+      - name: Create release
         # Only run for the PHP version specified in the git tag.
         #
         # This if could be moved to the parent `job` section when it's
@@ -81,7 +107,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.ref_name }} --generate-notes \
-            php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}.wasm \
-            php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}.size-optimized.wasm \
-            php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}.speed-optimized.wasm
+          gh release create --generate-notes ${{ github.ref_name }} || true
+      - name: Append php-cgi release assets
+        # Only run for the PHP version specified in the git tag.
+        #
+        # This if could be moved to the parent `job` section when it's
+        # supported by GitHub (https://github.com/community/community/discussions/37883)
+        if: ${{ startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))}}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} \
+            php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm \
+            php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.size-optimized.wasm \
+            php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.speed-optimized.wasm
+
+      - name: Append php release assets
+        # Only run for the PHP version specified in the git tag.
+        #
+        # This if could be moved to the parent `job` section when it's
+        # supported by GitHub (https://github.com/community/community/discussions/37883)
+        if: ${{ startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version)) && matrix.build-php-cli }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} \
+            php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.wasm \
+            php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.size-optimized.wasm \
+            php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.speed-optimized.wasm

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@
 php/php-*:
 	make -C php $(subst php/php-,php-,$@)
 
+.PHONY: php/wasmedge-php-7.4.32
+php/wasmedge-php-7.4.32:
+	WASMLABS_RUNTIME=wasmedge make -C php $(subst php/wasmedge-php-,php-,$@)
+
 .PHONY: clean
 clean:
 	make -C php clean

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All you need in order to run these builds is to have `docker` or `podman` availa
 - `php/php-7.3.33`
     - Resulting binaries are placed in `php/build-output/php/php-7.3.33/bin`.
 
-- `php/php-7.4.32`
+- `php/php-7.4.32`, `php/wasmedge-php-7.4.32`
     - Resulting binaries are placed in `php/build-output/php/php-7.4.32/bin`.
 
 ### Build strategy

--- a/php/Makefile
+++ b/php/Makefile
@@ -11,7 +11,7 @@ php-builder: wasi-builder-16
 .PHONY: php-*
 php-*: php-builder
 	mkdir -p build-output build-staging
-	docker run --rm -v ${ROOT_DIR}/build-output:/wlr/build-output -v ${ROOT_DIR}/build-staging:/wlr/build-staging ghcr.io/vmware-labs/php-builder:wasi-${WASI_SDK_VERSION} ./wl-make.sh php/$@
+	docker run --rm -e WASMLABS_RUNTIME -v ${ROOT_DIR}/build-output:/wlr/build-output -v ${ROOT_DIR}/build-staging:/wlr/build-staging ghcr.io/vmware-labs/php-builder:wasi-${WASI_SDK_VERSION} ./wl-make.sh php/$@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This target generates a specific PHP CLI targeting wasmedge. This allows for this WebAssembly module to, e.g. perform a `socket` call in order to create a listening socket as opposed to a socket being created by the host, and the file descriptor being forwarded to the WebAssembly module.

It also exports  a `connect` function that resembles `connect(3)`.

The `WASMLABS_RUNTIME` is exposed to the build scripts in order to produce the specified target.

An example of this workflow run: https://github.com/ereslibre/webassembly-language-runtimes/releases/tag/php%2F7.4.32%2B20221223-4e86d34