### PR TITLE
Add support for php8

### DIFF
--- a/php/php-8.1.11/README.md
+++ b/php/php-8.1.11/README.md
@@ -15,7 +15,7 @@ We are not using mman emulation due to the reasons outlined [below](#mmap-suppor
 This describes the most common places where we needed to exclude code because
 a method or constant is not available or is somehow different with WASI.
 
-## S_IFSOCK is the same as  S_IFFIFO
+## S_IFSOCK is the same as S_IFIFO
 
 WASI snapshot2 is not out yet - https://github.com/nodejs/uvwasi/issues/59.
 

--- a/php/php-8.1.11/README.md
+++ b/php/php-8.1.11/README.md
@@ -30,7 +30,8 @@ We've commented out the S_IFFIFO cases.
 There is no such support in WASI yet.
 
 We have taken a shortcut and just botched the exception handling in the zend
-zend engine. The program will just ignore exceptions as they happen.
+engine. The program will just ignore certain exceptions at the PHP engine level
+(exceptions raised from within PHP scripts work).
 
 ## sqlite3 support
 

--- a/php/php-8.1.11/README.md
+++ b/php/php-8.1.11/README.md
@@ -1,0 +1,85 @@
+# About
+
+This contains a non-exhaustive list of changes that we had to make to be able to build the PHP codebase for wasm32-wasi.
+
+To remove or add code for wasm32-wasi builds we are using the 'WASM_WASI' macro.
+
+# emulated functionality
+
+We are using emulation of getpid, signals and clocks.
+
+We are not using mman emulation due to the reasons outlined [below](#mmap-support).
+
+# excluded code
+
+This describes the most common places where we needed to exclude code because
+a method or constant is not available or is somehow different with WASI.
+
+## S_IFSOCK is the same as  S_IFFIFO
+
+WASI snapshot2 is not out yet - https://github.com/nodejs/uvwasi/issues/59.
+
+Thus there is no support for a FIFO filetype. So the two constants were
+defined to the same value. Because of this a switch/case on file type will fail
+due to duplicate case labels.
+
+We've commented out the S_IFFIFO cases.
+
+## setjmp and longjmp
+
+There is no such support in WASI yet.
+
+We have taken a shortcut and just botched the exception handling in the zend
+zend engine. The program will just ignore exceptions as they happen.
+
+## sqlite3 support
+
+We are using sqlite 3.39.2 instead of the original 3.28.0 that goes with php 7.3.33.
+
+Additionally sqlite3 had to be modified in some ways for WASM_WASI builds:
+
+ - mark fchmod, fchown as not defined
+ - use "dotlockIoFinder" for file locking
+ - skip sqlite3_finalize
+
+## unsupported posix methods
+
+We have stubbed the posix methods in `ext/posix/posix.c` which are not supported for WASI.
+
+Other methods, which are direcly used without wrapping were skipped in place by stubbing
+the method that is calling them.
+
+## php flock
+
+File locking is also stubbed and always returns success.
+
+## mmap support
+
+**TL;DR:** 
+
+We are building without MMAP support. To make it work, changes had to be made to zend_alloc.c resulting in a slower but correct behavior.
+
+
+**Details:** 
+
+Take a look [here](https://linux.die.net/man/2/mmap) for the docs for mmap and munmap
+
+The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-16 tag).
+
+ - mmap uses malloc to reserve the necessary amount of memory (always ignoring the addr hint)
+ - mmap zeroes out bytes if MAP_ANONYMOUS is used
+ - mmap reads file contents if mapping an fd
+ - munmap only supports unmapping of the exact same chunk (addr + size) that was previously mapped - as it is effectively a free of the malloc-ed memory
+
+In the php code there are two places where mman.h is used
+
+1. In zend_alloc.c - for custom memory allocation
+
+ - there is code that relies on partial munmap (for the sake of proper alignment at higher level). Using the emulated mmap will lead to leaks here, as munmap fails.
+ - there is code that relies on the capability to extend a mmaped chunk - this will fail and lead to performance degradation (falling-back to reallocation)
+
+2. In plain_wrapper.c and zend_stream.c - for reading of the interpreted .php source files
+
+ - the tricky thing here is the ZEND_MMAP_AHEAD needed by the zend_language_scanner. The language parser depends on having a bunch of null-terminating characters at the end of the interpreted string. The usual mmap behavior guarantees that when files are mmaped memory is reserved in pages of size `sysconf(_SC_PAGE_SIZE)`, which is padded with `\0`-s after the file contents. However, the emulated mmap does not do that (as it only malloc-s what was requested). This leads to the parser reading random stuff from memory after the mmaped file contents. 
+
+

--- a/php/php-8.1.11/README.md
+++ b/php/php-8.1.11/README.md
@@ -4,13 +4,13 @@ This contains a non-exhaustive list of changes that we had to make to be able to
 
 To remove or add code for wasm32-wasi builds we are using the 'WASM_WASI' macro.
 
-# emulated functionality
+# Emulated functionality
 
 We are using emulation of getpid, signals and clocks.
 
 We are not using mman emulation due to the reasons outlined [below](#mmap-support).
 
-# excluded code
+# Excluded code
 
 This describes the most common places where we needed to exclude code because
 a method or constant is not available or is somehow different with WASI.
@@ -23,7 +23,7 @@ Thus there is no support for a FIFO filetype. So the two constants were
 defined to the same value. Because of this a switch/case on file type will fail
 due to duplicate case labels.
 
-We've commented out the S_IFFIFO cases.
+We've commented out the S_IFIFO cases.
 
 ## setjmp and longjmp
 
@@ -43,7 +43,7 @@ Additionally sqlite3 had to be modified in some ways for WASM_WASI builds:
  - use "dotlockIoFinder" for file locking
  - skip sqlite3_finalize
 
-## unsupported posix methods
+## Unsupported posix methods
 
 We have stubbed the posix methods in `ext/posix/posix.c` which are not supported for WASI.
 

--- a/php/php-8.1.11/patches/0001-Initial-port-of-the-php-7.4.32-patch-for-php-8.1.11.patch
+++ b/php/php-8.1.11/patches/0001-Initial-port-of-the-php-7.4.32-patch-for-php-8.1.11.patch
@@ -1,0 +1,2032 @@
+From 40323e33477a91a82d7259dbd988e398872f7c9a Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Tue, 8 Nov 2022 16:07:48 +0200
+Subject: [PATCH] Initial port of the php 7.4.32 patch for php 8.1.11
+
+
+  19.8% Zend/
+  16.0% ext/posix/
+  24.1% ext/standard/
+  14.4% main/streams/
+  17.2% main/
+   5.5% sapi/cgi/
+diff --git a/Zend/zend.c b/Zend/zend.c
+index be7fa210ff..6b1346abcc 100644
+--- a/Zend/zend.c
++++ b/Zend/zend.c
+@@ -785,7 +785,9 @@ static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{
+ #endif
+ 	executor_globals->saved_fpu_cw_ptr = NULL;
+ 	executor_globals->active = 0;
++#ifndef WASM_WASI
+ 	executor_globals->bailout = NULL;
++#endif // WASM_WASI
+ 	executor_globals->error_handling  = EH_NORMAL;
+ 	executor_globals->exception_class = NULL;
+ 	executor_globals->exception = NULL;
+@@ -1178,6 +1180,7 @@ ZEND_COLD void zenderror(const char *error) /* {{{ */
+ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32_t lineno) /* {{{ */
+ {
+ 
++#ifndef WASM_WASI
+ 	if (!EG(bailout)) {
+ 		zend_output_debug_string(1, "%s(%d) : Bailed out without a bailout address!", filename, lineno);
+ 		exit(-1);
+@@ -1188,6 +1191,7 @@ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32
+ 	CG(in_compilation) = 0;
+ 	EG(current_execute_data) = NULL;
+ 	LONGJMP(*EG(bailout), FAILURE);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/Zend/zend.h b/Zend/zend.h
+index ba80a804ed..12860f99c7 100644
+--- a/Zend/zend.h
++++ b/Zend/zend.h
+@@ -251,6 +251,7 @@ typedef size_t (*zend_write_func_t)(const char *str, size_t str_length);
+ 
+ #define zend_bailout()		_zend_bailout(__FILE__, __LINE__)
+ 
++#ifndef WASM_WASI
+ #define zend_try												\
+ 	{															\
+ 		JMP_BUF *__orig_bailout = EG(bailout);					\
+@@ -267,6 +268,19 @@ typedef size_t (*zend_write_func_t)(const char *str, size_t str_length);
+ 	}
+ #define zend_first_try		EG(bailout)=NULL;	zend_try
+ 
++#else // WASM_WASI
++#define zend_try												\
++	{															\
++		if (1) {
++#define zend_catch												\
++		} else {
++#define zend_end_try()											\
++		}														\
++	}
++#define zend_first_try		zend_try
++#endif // WASM_WASI
++
++
+ BEGIN_EXTERN_C()
+ void zend_startup(zend_utility_functions *utility_functions);
+ void zend_shutdown(void);
+diff --git a/Zend/zend_alloc.c b/Zend/zend_alloc.c
+index dfdc4e2bb4..b224d5cc78 100644
+--- a/Zend/zend_alloc.c
++++ b/Zend/zend_alloc.c
+@@ -79,7 +79,7 @@
+ #include <fcntl.h>
+ #include <errno.h>
+ 
+-#ifndef _WIN32
++#if !defined(_WIN32) && HAVE_MMAP
+ # include <sys/mman.h>
+ # ifndef MAP_ANON
+ #  ifdef MAP_ANONYMOUS
+@@ -421,6 +421,8 @@ static void *zend_mm_mmap_fixed(void *addr, size_t size)
+ {
+ #ifdef _WIN32
+ 	return VirtualAlloc(addr, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
++#elif ! HAVE_MMAP
++	return NULL;
+ #else
+ 	int flags = MAP_PRIVATE | MAP_ANON;
+ #if defined(MAP_EXCL)
+@@ -459,6 +461,10 @@ static void *zend_mm_mmap(size_t size)
+ 		return NULL;
+ 	}
+ 	return ptr;
++#elif ! HAVE_MMAP
++	void* ptr = malloc(size);
++	memset(ptr, 0, size);
++	return ptr;
+ #else
+ 	void *ptr;
+ 
+@@ -491,6 +497,8 @@ static void zend_mm_munmap(void *addr, size_t size)
+ 		stderr_last_error("VirtualFree() failed");
+ #endif
+ 	}
++#elif ! HAVE_MMAP
++	free(addr);
+ #else
+ 	if (munmap(addr, size) != 0) {
+ #if ZEND_MM_ERROR
+@@ -664,6 +672,11 @@ static zend_always_inline int zend_mm_bitset_is_free_range(zend_mm_bitset *bitse
+ 
+ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
+ {
++#if ! HAVE_MMAP
++	void* ptr = aligned_alloc(alignment, size);
++	memset(ptr, 0, size);
++	return ptr;
++#else
+ 	void *ptr = zend_mm_mmap(size);
+ 
+ 	if (ptr == NULL) {
+@@ -710,6 +723,7 @@ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
+ #endif
+ 		return ptr;
+ 	}
++#endif
+ }
+ 
+ static void *zend_mm_chunk_alloc(zend_mm_heap *heap, size_t size, size_t alignment)
+@@ -2860,7 +2874,7 @@ ZEND_API void start_memory_manager(void)
+ #else
+ 	alloc_globals_ctor(&alloc_globals);
+ #endif
+-#ifndef _WIN32
++#if !defined(_WIN32) && HAVE_MMAP
+ #  if defined(_SC_PAGESIZE)
+ 	REAL_PAGE_SIZE = sysconf(_SC_PAGESIZE);
+ #  elif defined(_SC_PAGE_SIZE)
+diff --git a/Zend/zend_fibers.c b/Zend/zend_fibers.c
+index 1fec85528f..5f692bf128 100644
+--- a/Zend/zend_fibers.c
++++ b/Zend/zend_fibers.c
+@@ -36,7 +36,7 @@
+ # include <ucontext.h>
+ #endif
+ 
+-#ifndef ZEND_WIN32
++#if !defined(ZEND_WIN32) && HAVE_MMAP
+ # include <unistd.h>
+ # include <sys/mman.h>
+ # include <limits.h>
+@@ -91,7 +91,9 @@ typedef struct _zend_fiber_vm_state {
+ 	zend_execute_data *current_execute_data;
+ 	int error_reporting;
+ 	uint32_t jit_trace_num;
++#ifndef WASM_WASI
+ 	JMP_BUF *bailout;
++#endif // WASM_WASI
+ 	zend_fiber *active_fiber;
+ } zend_fiber_vm_state;
+ 
+@@ -104,7 +106,9 @@ static zend_always_inline void zend_fiber_capture_vm_state(zend_fiber_vm_state *
+ 	state->current_execute_data = EG(current_execute_data);
+ 	state->error_reporting = EG(error_reporting);
+ 	state->jit_trace_num = EG(jit_trace_num);
++#ifndef WASM_WASI
+ 	state->bailout = EG(bailout);
++#endif // WASM_WASI
+ 	state->active_fiber = EG(active_fiber);
+ }
+ 
+@@ -117,7 +121,9 @@ static zend_always_inline void zend_fiber_restore_vm_state(zend_fiber_vm_state *
+ 	EG(current_execute_data) = state->current_execute_data;
+ 	EG(error_reporting) = state->error_reporting;
+ 	EG(jit_trace_num) = state->jit_trace_num;
++#ifndef WASM_WASI
+ 	EG(bailout) = state->bailout;
++#endif // WASM_WASI
+ 	EG(active_fiber) = state->active_fiber;
+ }
+ 
+@@ -203,6 +209,8 @@ static zend_fiber_stack *zend_fiber_stack_allocate(size_t size)
+ 		return NULL;
+ 	}
+ # endif
++#elif defined(WASM_WASI)
++	pointer = malloc(alloc_size);
+ #else
+ 	pointer = mmap(NULL, alloc_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+ 
+@@ -250,6 +258,8 @@ static void zend_fiber_stack_free(zend_fiber_stack *stack)
+ 
+ #ifdef ZEND_WIN32
+ 	VirtualFree(pointer, 0, MEM_RELEASE);
++#elif defined(WASM_WASI)
++	free(pointer);
+ #else
+ 	munmap(pointer, stack->size + ZEND_FIBER_GUARD_PAGES * page_size);
+ #endif
+diff --git a/Zend/zend_globals.h b/Zend/zend_globals.h
+index 1726dee9ac..091aa91107 100644
+--- a/Zend/zend_globals.h
++++ b/Zend/zend_globals.h
+@@ -21,7 +21,9 @@
+ #define ZEND_GLOBALS_H
+ 
+ 
++#ifndef WASM_WASI
+ #include <setjmp.h>
++#endif
+ 
+ #include "zend_globals_macros.h"
+ 
+@@ -156,7 +158,9 @@ struct _zend_executor_globals {
+ 
+ 	HashTable included_files;	/* files already included */
+ 
++#ifndef WASM_WASI
+ 	JMP_BUF *bailout;
++#endif
+ 
+ 	int error_reporting;
+ 	int exit_status;
+diff --git a/Zend/zend_types.h b/Zend/zend_types.h
+index 3d42d481a6..0ff33b0300 100644
+--- a/Zend/zend_types.h
++++ b/Zend/zend_types.h
+@@ -1427,5 +1427,15 @@ static zend_always_inline uint32_t zval_delref_p(zval* pz) {
+ #define ZVAL_COPY_OR_DUP_PROP(z, v) \
+ 	do { ZVAL_COPY_OR_DUP(z, v); Z_PROP_FLAG_P(z) = Z_PROP_FLAG_P(v); } while (0)
+ 
++#ifdef WASM_WASI
++#define	LOG_EMERG	0	/* system is unusable */
++#define	LOG_ALERT	1	/* action must be taken immediately */
++#define	LOG_CRIT	2	/* critical conditions */
++#define	LOG_ERR		3	/* error conditions */
++#define	LOG_WARNING	4	/* warning conditions */
++#define	LOG_NOTICE	5	/* normal but significant condition */
++#define	LOG_INFO	6	/* informational */
++#define	LOG_DEBUG	7	/* debug-level messages */
++#endif // WASM_WASI
+ 
+ #endif /* ZEND_TYPES_H */
+diff --git a/Zend/zend_virtual_cwd.c b/Zend/zend_virtual_cwd.c
+index d8a9046d04..94964aa394 100644
+--- a/Zend/zend_virtual_cwd.c
++++ b/Zend/zend_virtual_cwd.c
+@@ -1393,6 +1393,8 @@ CWD_API int virtual_chmod(const char *filename, mode_t mode) /* {{{ */
+ 		}
+ 		ret = php_win32_ioutil_chmod(new_state.cwd, mode);
+ 	}
++#elif defined WASM_WASI
++	ret = 0;
+ #else
+ 	ret = chmod(new_state.cwd, mode);
+ #endif
+@@ -1421,7 +1423,11 @@ CWD_API int virtual_chown(const char *filename, uid_t owner, gid_t group, int li
+ 		ret = -1;
+ #endif
+ 	} else {
++#ifndef WASM_WASI
+ 		ret = chown(new_state.cwd, owner, group);
++#else
++		ret = 0;
++#endif // WASM_WASI
+ 	}
+ 
+ 	CWD_STATE_FREE_ERR(&new_state);
+@@ -1699,8 +1705,11 @@ CWD_API FILE *virtual_popen(const char *command, const char *type) /* {{{ */
+ 	*ptr++ = ' ';
+ 
+ 	memcpy(ptr, command, command_length+1);
++#ifndef WASM_WASI
+ 	retval = popen(command_line, type);
+-
++#else
++	retval = 0;
++#endif // WASM_WASI
+ 	efree(command_line);
+ 	return retval;
+ }
+diff --git a/ext/fileinfo/libmagic/compress.c b/ext/fileinfo/libmagic/compress.c
+index 85d0b2938e..0129c20341 100644
+--- a/ext/fileinfo/libmagic/compress.c
++++ b/ext/fileinfo/libmagic/compress.c
+@@ -453,7 +453,7 @@ file_pipe2file(struct magic_set *ms, int fd, const void *startbuf,
+ 	int tfd;
+ 
+ 	(void)strlcpy(buf, "/tmp/file.XXXXXX", sizeof buf);
+-#ifndef HAVE_MKSTEMP
++#if !defined(HAVE_MKSTEMP) && !defined(WASM_WASI)
+ 	{
+ 		char *ptr = mktemp(buf);
+ 		tfd = open(ptr, O_RDWR|O_TRUNC|O_EXCL|O_CREAT, 0600);
+diff --git a/ext/fileinfo/libmagic/fsmagic.c b/ext/fileinfo/libmagic/fsmagic.c
+index a1b18d479f..ff43d7bebc 100644
+--- a/ext/fileinfo/libmagic/fsmagic.c
++++ b/ext/fileinfo/libmagic/fsmagic.c
+@@ -167,6 +167,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, zend_stat_t *sb)
+ # endif
+ #endif
+ 
++#ifndef WASM_WASI
+ #ifdef	S_IFIFO
+ 	case S_IFIFO:
+ 		if((ms->flags & MAGIC_DEVICES) != 0)
+@@ -179,6 +180,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, zend_stat_t *sb)
+ 			return -1;
+ 		break;
+ #endif
++#endif // WASM_WASI
+ #ifdef	S_IFDOOR
+ 	case S_IFDOOR:
+ 		if (mime) {
+diff --git a/ext/pdo_sqlite/sqlite_statement.c b/ext/pdo_sqlite/sqlite_statement.c
+index 90de059a3b..2e83f01af6 100644
+--- a/ext/pdo_sqlite/sqlite_statement.c
++++ b/ext/pdo_sqlite/sqlite_statement.c
+@@ -32,7 +32,9 @@ static int pdo_sqlite_stmt_dtor(pdo_stmt_t *stmt)
+ 	pdo_sqlite_stmt *S = (pdo_sqlite_stmt*)stmt->driver_data;
+ 
+ 	if (S->stmt) {
++#ifndef WASM_WASI
+ 		sqlite3_finalize(S->stmt);
++#endif
+ 		S->stmt = NULL;
+ 	}
+ 	efree(S);
+diff --git a/ext/posix/posix.c b/ext/posix/posix.c
+index e6655f0d95..9b5e6431af 100644
+--- a/ext/posix/posix.c
++++ b/ext/posix/posix.c
+@@ -38,8 +38,10 @@
+ #include <signal.h>
+ #include <sys/times.h>
+ #include <errno.h>
++#ifndef WASM_WASI
+ #include <grp.h>
+ #include <pwd.h>
++#endif // WASM_WASI
+ #ifdef HAVE_SYS_MKDEV_H
+ # include <sys/mkdev.h>
+ #endif
+@@ -196,6 +198,7 @@ ZEND_GET_MODULE(posix)
+ 
+ PHP_FUNCTION(posix_kill)
+ {
++#ifndef WASM_WASI
+ 	zend_long pid, sig;
+ 
+ 	ZEND_PARSE_PARAMETERS_START(2, 2)
+@@ -207,7 +210,7 @@ PHP_FUNCTION(posix_kill)
+ 		POSIX_G(last_error) = errno;
+ 		RETURN_FALSE;
+ 	}
+-
++#endif // WASM_WASI
+ 	RETURN_TRUE;
+ }
+ /* }}} */
+@@ -215,56 +218,88 @@ PHP_FUNCTION(posix_kill)
+ /* {{{ Get the current process id (POSIX.1, 4.1.1) */
+ PHP_FUNCTION(posix_getpid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getpid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Get the parent process id (POSIX.1, 4.1.1) */
+ PHP_FUNCTION(posix_getppid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getppid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Get the current user id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_getuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Get the current group id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_getgid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getgid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Get the current effective user id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_geteuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(geteuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Get the current effective group id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_getegid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getegid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Set user id (POSIX.1, 4.2.2) */
+ PHP_FUNCTION(posix_setuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(setuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Set group id (POSIX.1, 4.2.2) */
+ PHP_FUNCTION(posix_setgid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(setgid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -272,7 +307,11 @@ PHP_FUNCTION(posix_setgid)
+ #ifdef HAVE_SETEUID
+ PHP_FUNCTION(posix_seteuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(seteuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ #endif
+ /* }}} */
+@@ -281,7 +320,11 @@ PHP_FUNCTION(posix_seteuid)
+ #ifdef HAVE_SETEGID
+ PHP_FUNCTION(posix_setegid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(setegid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ #endif
+ /* }}} */
+@@ -341,7 +384,11 @@ PHP_FUNCTION(posix_getlogin)
+ /* {{{ Get current process group id (POSIX.1, 4.3.1) */
+ PHP_FUNCTION(posix_getpgrp)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getpgrp);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -349,7 +396,11 @@ PHP_FUNCTION(posix_getpgrp)
+ #ifdef HAVE_SETSID
+ PHP_FUNCTION(posix_setsid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(setsid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ #endif
+ /* }}} */
+@@ -357,6 +408,7 @@ PHP_FUNCTION(posix_setsid)
+ /* {{{ Set process group id for job control (POSIX.1, 4.3.3) */
+ PHP_FUNCTION(posix_setpgid)
+ {
++#ifndef WASM_WASI
+ 	zend_long pid, pgid;
+ 
+ 	ZEND_PARSE_PARAMETERS_START(2, 2)
+@@ -368,6 +420,7 @@ PHP_FUNCTION(posix_setpgid)
+ 		POSIX_G(last_error) = errno;
+ 		RETURN_FALSE;
+ 	}
++#endif // WASM_WASI
+ 
+ 	RETURN_TRUE;
+ }
+@@ -535,6 +588,7 @@ PHP_FUNCTION(posix_ttyname)
+ 		default:
+ 			fd = zval_get_long(z_fd);
+ 	}
++#ifndef WASM_WASI
+ #if defined(ZTS) && defined(HAVE_TTYNAME_R) && defined(_SC_TTY_NAME_MAX)
+ 	buflen = sysconf(_SC_TTY_NAME_MAX);
+ 	if (buflen < 1) {
+@@ -555,7 +609,8 @@ PHP_FUNCTION(posix_ttyname)
+ 		RETURN_FALSE;
+ 	}
+ #endif
+-	RETURN_STRING(p);
++#endif // WASM_WASI
++	RETURN_STRING("");
+ }
+ /* }}} */
+ 
+@@ -701,6 +756,7 @@ int php_posix_group_to_array(struct group *g, zval *array_group) /* {{{ */
+ 	zval array_members;
+ 	int count;
+ 
++#ifndef WASM_WASI
+ 	if (NULL == g)
+ 		return 0;
+ 
+@@ -728,6 +784,9 @@ int php_posix_group_to_array(struct group *g, zval *array_group) /* {{{ */
+ 	zend_hash_str_update(Z_ARRVAL_P(array_group), "members", sizeof("members")-1, &array_members);
+ 	add_assoc_long(array_group, "gid", g->gr_gid);
+ 	return 1;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -785,6 +844,7 @@ PHP_FUNCTION(posix_access)
+ /* {{{ Group database access (POSIX.1, 9.2.1) */
+ PHP_FUNCTION(posix_getgrnam)
+ {
++#ifndef WASM_WASI
+ 	char *name;
+ 	struct group *g;
+ 	size_t name_len;
+@@ -833,12 +893,16 @@ try_again:
+ #if defined(ZTS) && defined(HAVE_GETGRNAM_R) && defined(_SC_GETGR_R_SIZE_MAX)
+ 	efree(buf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Group database access (POSIX.1, 9.2.1) */
+ PHP_FUNCTION(posix_getgrgid)
+ {
++#ifndef WASM_WASI
+ 	zend_long gid;
+ #if defined(ZTS) && defined(HAVE_GETGRGID_R) && defined(_SC_GETGR_R_SIZE_MAX)
+ 	int ret;
+@@ -891,11 +955,15 @@ try_again:
+ #if defined(ZTS) && defined(HAVE_GETGRGID_R) && defined(_SC_GETGR_R_SIZE_MAX)
+ 	efree(grbuf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ int php_posix_passwd_to_array(struct passwd *pw, zval *return_value) /* {{{ */
+ {
++#ifndef WASM_WASI
+ 	if (NULL == pw)
+ 		return 0;
+ 	if (NULL == return_value || Z_TYPE_P(return_value) != IS_ARRAY)
+@@ -909,12 +977,16 @@ int php_posix_passwd_to_array(struct passwd *pw, zval *return_value) /* {{{ */
+ 	add_assoc_string(return_value, "dir",       pw->pw_dir);
+ 	add_assoc_string(return_value, "shell",     pw->pw_shell);
+ 	return 1;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ User database access (POSIX.1, 9.2.2) */
+ PHP_FUNCTION(posix_getpwnam)
+ {
++#ifndef WASM_WASI
+ 	struct passwd *pw;
+ 	char *name;
+ 	size_t name_len;
+@@ -963,12 +1035,16 @@ try_again:
+ #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWNAM_R)
+ 	efree(buf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ User database access (POSIX.1, 9.2.2) */
+ PHP_FUNCTION(posix_getpwuid)
+ {
++#ifndef WASM_WASI
+ 	zend_long uid;
+ #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWUID_R)
+ 	struct passwd _pw;
+@@ -1019,6 +1095,9 @@ try_again:
+ #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWUID_R)
+ 	efree(pwbuf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/session/mod_files.c b/ext/session/mod_files.c
+index 1da25ba583..60d301f002 100644
+--- a/ext/session/mod_files.c
++++ b/ext/session/mod_files.c
+@@ -192,6 +192,7 @@ static void ps_files_open(ps_files *data, const char *key)
+ #endif
+ 
+ 		if (data->fd != -1) {
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ 			/* check that this session file was created by us or root – we
+ 			   don't want to end up accepting the sessions of another webapp
+@@ -211,6 +212,7 @@ static void ps_files_open(ps_files *data, const char *key)
+ 			do {
+ 				ret = flock(data->fd, LOCK_EX);
+ 			} while (ret == -1 && errno == EINTR);
++#endif // WASM_WASI
+ 
+ #ifdef F_SETFD
+ # ifndef FD_CLOEXEC
+diff --git a/ext/standard/basic_functions.c b/ext/standard/basic_functions.c
+index 23f736d200..09e2ff676a 100755
+--- a/ext/standard/basic_functions.c
++++ b/ext/standard/basic_functions.c
+@@ -61,11 +61,13 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
+ #include <sys/stat.h>
+ #endif
+ 
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ # include <netdb.h>
+ #else
+ #include "win32/inet.h"
+ #endif
++#endif // WASM_WASI
+ 
+ #if HAVE_ARPA_INET_H
+ # include <arpa/inet.h>
+@@ -520,9 +522,11 @@ PHP_RSHUTDOWN_FUNCTION(basic) /* {{{ */
+ 
+ 	BG(mt_rand_is_seeded) = 0;
+ 
++#ifndef WASM_WASI
+ 	if (BG(umask) != -1) {
+ 		umask(BG(umask));
+ 	}
++#endif // WASM_WASI
+ 
+ 	/* Check if locale was changed and change it back
+ 	 * to the value in startup environment */
+@@ -2456,6 +2460,7 @@ PHP_FUNCTION(move_uploaded_file)
+ 
+ 	if (VCWD_RENAME(path, new_path) == 0) {
+ 		successful = 1;
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ 		oldmask = umask(077);
+ 		umask(oldmask);
+@@ -2466,6 +2471,7 @@ PHP_FUNCTION(move_uploaded_file)
+ 			php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+ 		}
+ #endif
++#endif // WASM_WASI
+ 	} else if (php_copy_file_ex(path, new_path, STREAM_DISABLE_OPEN_BASEDIR) == SUCCESS) {
+ 		VCWD_UNLINK(path);
+ 		successful = 1;
+diff --git a/ext/standard/dns.c b/ext/standard/dns.c
+index 6d22e644a8..902f726b05 100644
+--- a/ext/standard/dns.c
++++ b/ext/standard/dns.c
+@@ -34,7 +34,9 @@
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif // WASM_WASI
+ #ifdef _OSD_POSIX
+ #undef STATUS
+ #undef T_UNSPEC
+@@ -172,6 +174,7 @@ PHP_FUNCTION(gethostbyaddr)
+ /* {{{ php_gethostbyaddr */
+ static zend_string *php_gethostbyaddr(char *ip)
+ {
++#ifndef WASM_WASI
+ #if HAVE_IPV6 && HAVE_INET_PTON
+ 	struct sockaddr_in sa4;
+ 	struct sockaddr_in6 sa6;
+@@ -213,6 +216,9 @@ static zend_string *php_gethostbyaddr(char *ip)
+ 
+ 	return zend_string_init(hp->h_name, strlen(hp->h_name), 0);
+ #endif
++#else
++	return NULL;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -239,6 +245,7 @@ PHP_FUNCTION(gethostbyname)
+ /* {{{ Return a list of IP addresses that a given hostname resolves to. */
+ PHP_FUNCTION(gethostbynamel)
+ {
++#ifndef WASM_WASI
+ 	char *hostname;
+ 	size_t hostname_len;
+ 	struct hostent *hp;
+@@ -280,12 +287,16 @@ PHP_FUNCTION(gethostbynamel)
+ 		add_next_index_string(return_value, inet_ntoa(in));
+ #endif
+ 	}
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ php_gethostbyname */
+ static zend_string *php_gethostbyname(char *name)
+ {
++#ifndef WASM_WASI
+ 	struct hostent *hp;
+ 	struct in_addr *h_addr_0; /* Don't call this h_addr, it's a macro! */
+ 	struct in_addr in;
+@@ -313,6 +324,9 @@ static zend_string *php_gethostbyname(char *name)
+ 	address = inet_ntoa(in);
+ #endif
+ 	return zend_string_init(address, strlen(address), 0);
++#else
++	return NULL;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/exec.c b/ext/standard/exec.c
+index 1831b8eaa5..a4df3a8a5b 100644
+--- a/ext/standard/exec.c
++++ b/ext/standard/exec.c
+@@ -113,6 +113,7 @@ static size_t handle_line(int type, zval *array, char *buf, size_t bufl) {
+  */
+ PHPAPI int php_exec(int type, const char *cmd, zval *array, zval *return_value)
+ {
++#ifndef WASM_WASI
+ 	FILE *fp;
+ 	char *buf;
+ 	int pclose_return;
+@@ -200,7 +201,10 @@ err:
+ 	pclose_return = -1;
+ 	RETVAL_FALSE;
+ 	goto done;
+-}
++#else
++	return 0;
++#endif // WASM_WASI
++ }
+ /* }}} */
+ 
+ static void php_exec_ex(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
+@@ -512,6 +516,7 @@ PHP_FUNCTION(escapeshellarg)
+ /* {{{ Execute command via shell and return complete output as string */
+ PHP_FUNCTION(shell_exec)
+ {
++#ifndef WASM_WASI
+ 	FILE *in;
+ 	char *command;
+ 	size_t command_len;
+@@ -547,7 +552,10 @@ PHP_FUNCTION(shell_exec)
+ 	if (ret && ZSTR_LEN(ret) > 0) {
+ 		RETVAL_STR(ret);
+ 	}
+-}
++#else
++	RETURN_FALSE;
++#endif
++ }
+ /* }}} */
+ 
+ #ifdef HAVE_NICE
+diff --git a/ext/standard/file.c b/ext/standard/file.c
+index 4c31ee0eae..5abc991341 100644
+--- a/ext/standard/file.c
++++ b/ext/standard/file.c
+@@ -55,7 +55,9 @@
+ # endif
+ # include <sys/socket.h>
+ # include <netinet/in.h>
+-# include <netdb.h>
++# ifndef WASM_WASI
++#  include <netdb.h>
++# endif // WASM_WASI
+ # if HAVE_ARPA_INET_H
+ #  include <arpa/inet.h>
+ # endif
+@@ -923,6 +925,7 @@ PHPAPI PHP_FUNCTION(fclose)
+ /* {{{ Execute a command and open either a read or a write pipe to it */
+ PHP_FUNCTION(popen)
+ {
++#ifndef WASM_WASI
+ 	char *command, *mode;
+ 	size_t command_len, mode_len;
+ 	FILE *fp;
+@@ -972,6 +975,9 @@ PHP_FUNCTION(popen)
+ 	}
+ 
+ 	efree(posix_mode);
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -1353,6 +1359,7 @@ PHP_FUNCTION(readfile)
+ /* {{{ Return or change the umask */
+ PHP_FUNCTION(umask)
+ {
++#ifndef WASM_WASI
+ 	zend_long mask = 0;
+ 	bool mask_is_null = 1;
+ 	int oldumask;
+@@ -1375,6 +1382,9 @@ PHP_FUNCTION(umask)
+ 	}
+ 
+ 	RETURN_LONG(oldumask);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/filestat.c b/ext/standard/filestat.c
+index 83fc6837c6..65b854c7cf 100644
+--- a/ext/standard/filestat.c
++++ b/ext/standard/filestat.c
+@@ -326,12 +326,16 @@ PHPAPI int php_get_gid_by_name(const char *name, gid_t *gid)
+ 		efree(grbuf);
+ 		*gid = gr.gr_gid;
+ #else
++#ifndef WASM_WASI
+ 		struct group *gr = getgrnam(name);
+ 
+ 		if (!gr) {
+ 			return FAILURE;
+ 		}
+ 		*gid = gr->gr_gid;
++#else
++		*gid = 0;
++#endif // WASM_WASI
+ #endif
+ 		return SUCCESS;
+ }
+@@ -399,6 +403,7 @@ static void php_do_chgrp(INTERNAL_FUNCTION_PARAMETERS, int do_lchgrp) /* {{{ */
+ 		RETURN_FALSE;
+ 	}
+ 
++#ifndef WASM_WASI
+ 	if (do_lchgrp) {
+ #if HAVE_LCHOWN
+ 		ret = VCWD_LCHOWN(filename, -1, gid);
+@@ -410,6 +415,7 @@ static void php_do_chgrp(INTERNAL_FUNCTION_PARAMETERS, int do_lchgrp) /* {{{ */
+ 		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+ 		RETURN_FALSE;
+ 	}
++#endif // WASM_WASI
+ 	RETURN_TRUE;
+ #endif
+ }
+@@ -452,12 +458,16 @@ PHPAPI uid_t php_get_uid_by_name(const char *name, uid_t *uid)
+ 		efree(pwbuf);
+ 		*uid = pw.pw_uid;
+ #else
++#ifndef WASM_WASI
+ 		struct passwd *pw = getpwnam(name);
+ 
+ 		if (!pw) {
+ 			return FAILURE;
+ 		}
+ 		*uid = pw->pw_uid;
++#else
++		*uid = 0;
++#endif // WASM_WASI
+ #endif
+ 		return SUCCESS;
+ }
+@@ -465,6 +475,7 @@ PHPAPI uid_t php_get_uid_by_name(const char *name, uid_t *uid)
+ 
+ static void php_do_chown(INTERNAL_FUNCTION_PARAMETERS, int do_lchown) /* {{{ */
+ {
++#ifndef WASM_WASI
+ 	char *filename;
+ 	size_t filename_len;
+ 	zend_string *user_str;
+@@ -539,6 +550,9 @@ static void php_do_chown(INTERNAL_FUNCTION_PARAMETERS, int do_lchown) /* {{{ */
+ 	}
+ 	RETURN_TRUE;
+ #endif
++#else
++	RETURN_TRUE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -563,6 +577,7 @@ PHP_FUNCTION(lchown)
+ /* {{{ Change file mode */
+ PHP_FUNCTION(chmod)
+ {
++#ifndef WASM_WASI
+ 	char *filename;
+ 	size_t filename_len;
+ 	zend_long mode;
+@@ -601,6 +616,7 @@ PHP_FUNCTION(chmod)
+ 		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+ 		RETURN_FALSE;
+ 	}
++#endif // WASM_WASI
+ 	RETURN_TRUE;
+ }
+ /* }}} */
+@@ -855,6 +871,7 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
+ 
+ 	stat_sb = &ssb.sb;
+ 
++#ifndef WASM_WASI
+ 	if (type >= FS_IS_W && type <= FS_IS_X) {
+ 		if(ssb.sb.st_uid==getuid()) {
+ 			rmask=S_IRUSR;
+@@ -895,6 +912,7 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
+ 			}
+ 		}
+ 	}
++#endif // WASM_WASI
+ 
+ 	switch (type) {
+ 	case FS_PERMS:
+@@ -919,7 +937,9 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
+ 			RETURN_STRING("link");
+ 		}
+ 		switch(ssb.sb.st_mode & S_IFMT) {
++#ifndef WASM_WASI
+ 		case S_IFIFO: RETURN_STRING("fifo");
++#endif // WASM_WASI
+ 		case S_IFCHR: RETURN_STRING("char");
+ 		case S_IFDIR: RETURN_STRING("dir");
+ 		case S_IFBLK: RETURN_STRING("block");
+diff --git a/ext/standard/flock_compat.c b/ext/standard/flock_compat.c
+index 6b4fa3dced..03f6664a1b 100644
+--- a/ext/standard/flock_compat.c
++++ b/ext/standard/flock_compat.c
+@@ -26,7 +26,12 @@ PHPAPI int flock(int fd, int operation)
+ #endif /* !defined(HAVE_FLOCK) */
+ 
+ PHPAPI int php_flock(int fd, int operation)
+-#if HAVE_STRUCT_FLOCK /* {{{ */
++#if defined(WASM_WASI)
++{
++	errno = 0;
++	return 0;
++}
++#elif HAVE_STRUCT_FLOCK /* {{{ */
+ {
+ 	struct flock flck;
+ 	int ret;
+diff --git a/ext/standard/ftp_fopen_wrapper.c b/ext/standard/ftp_fopen_wrapper.c
+index f20f4245bd..34b882ddd1 100644
+--- a/ext/standard/ftp_fopen_wrapper.c
++++ b/ext/standard/ftp_fopen_wrapper.c
+@@ -48,7 +48,9 @@
+ #include <winsock2.h>
+ #else
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+diff --git a/ext/standard/http_fopen_wrapper.c b/ext/standard/http_fopen_wrapper.c
+index 5964efd2f9..de8f54a9d9 100644
+--- a/ext/standard/http_fopen_wrapper.c
++++ b/ext/standard/http_fopen_wrapper.c
+@@ -51,7 +51,9 @@
+ #include <winsock2.h>
+ #else
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+diff --git a/ext/standard/mail.c b/ext/standard/mail.c
+index 003fad3ea1..ae583a01db 100644
+--- a/ext/standard/mail.c
++++ b/ext/standard/mail.c
+@@ -372,6 +372,7 @@ static int php_mail_detect_multiple_crlf(const char *hdr) {
+ /* {{{ php_mail */
+ PHPAPI int php_mail(const char *to, const char *subject, const char *message, const char *headers, const char *extra_cmd)
+ {
++#ifndef WASM_WASI
+ #ifdef PHP_WIN32
+ 	int tsm_err;
+ 	char *tsm_errmsg = NULL;
+@@ -551,6 +552,9 @@ PHPAPI int php_mail(const char *to, const char *subject, const char *message, co
+ 	}
+ 
+ 	MAIL_RET(1); /* never reached */
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/microtime.c b/ext/standard/microtime.c
+index ca8643eb51..f39e90fdc0 100644
+--- a/ext/standard/microtime.c
++++ b/ext/standard/microtime.c
+@@ -126,6 +126,7 @@ PHP_FUNCTION(getrusage)
+ 	PHP_RUSAGE_PARA(ru_majflt);
+ 	PHP_RUSAGE_PARA(ru_maxrss);
+ #elif !defined(_OSD_POSIX) && !defined(__HAIKU__)
++#ifndef WASM_WASI
+ 	PHP_RUSAGE_PARA(ru_oublock);
+ 	PHP_RUSAGE_PARA(ru_inblock);
+ 	PHP_RUSAGE_PARA(ru_msgsnd);
+@@ -139,6 +140,7 @@ PHP_FUNCTION(getrusage)
+ 	PHP_RUSAGE_PARA(ru_nvcsw);
+ 	PHP_RUSAGE_PARA(ru_nivcsw);
+ 	PHP_RUSAGE_PARA(ru_nswap);
++#endif // WASM_WASI
+ #endif /*_OSD_POSIX*/
+ 	PHP_RUSAGE_PARA(ru_utime.tv_usec);
+ 	PHP_RUSAGE_PARA(ru_utime.tv_sec);
+diff --git a/ext/standard/net.c b/ext/standard/net.c
+index c549bfbc5b..32db22caa1 100644
+--- a/ext/standard/net.c
++++ b/ext/standard/net.c
+@@ -43,7 +43,7 @@
+ # include <ws2ipdef.h>
+ # include <Ws2tcpip.h>
+ # include <iphlpapi.h>
+-#else
++#elif ! defined(WASM_WASI)
+ # include <netdb.h>
+ #endif
+ 
+@@ -86,6 +86,7 @@ PHPAPI zend_string* php_inet_ntop(const struct sockaddr *addr) {
+ 			ZEND_FALLTHROUGH;
+ #endif
+ 		case AF_INET: {
++#ifndef WASM_WASI
+ 			zend_string *ret = zend_string_alloc(NI_MAXHOST, 0);
+ 			if (getnameinfo(addr, addrlen, ZSTR_VAL(ret), NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == SUCCESS) {
+ 				/* Also demangle numeric host with %name suffix */
+@@ -96,6 +97,9 @@ PHPAPI zend_string* php_inet_ntop(const struct sockaddr *addr) {
+ 			}
+ 			zend_string_efree(ret);
+ 			break;
++#else
++			return NULL;
++#endif // WASM_WASI
+ 		}
+ 	}
+ 
+diff --git a/ext/standard/pageinfo.c b/ext/standard/pageinfo.c
+index 06867fbda5..b789f99c55 100644
+--- a/ext/standard/pageinfo.c
++++ b/ext/standard/pageinfo.c
+@@ -61,8 +61,10 @@ PHPAPI void php_statpage(void)
+ 			BG(page_inode) = pstat->st_ino;
+ 			BG(page_mtime) = pstat->st_mtime;
+ 		} else { /* handler for situations where there is no source file, ex. php -r */
++#ifndef WASM_WASI
+ 			BG(page_uid) = getuid();
+ 			BG(page_gid) = getgid();
++#endif // WASM_WASI
+ 		}
+ 	}
+ }
+@@ -71,20 +73,29 @@ PHPAPI void php_statpage(void)
+ /* {{{ php_getuid */
+ zend_long php_getuid(void)
+ {
++#ifndef WASM_WASI
+ 	php_statpage();
+ 	return (BG(page_uid));
++#else
++	return 0;
++#endif //WASM_WASI
+ }
+ /* }}} */
+ 
+ zend_long php_getgid(void)
+ {
++#ifndef WASM_WASI
+ 	php_statpage();
+ 	return (BG(page_gid));
++#else
++	return 0;
++#endif //WASM_WASI
+ }
+ 
+ /* {{{ Get PHP script owner's UID */
+ PHP_FUNCTION(getmyuid)
+ {
++#ifndef WASM_WASI
+ 	zend_long uid;
+ 
+ 	ZEND_PARSE_PARAMETERS_NONE();
+@@ -95,6 +106,9 @@ PHP_FUNCTION(getmyuid)
+ 	} else {
+ 		RETURN_LONG(uid);
+ 	}
++#else
++	RETURN_LONG(0);
++#endif //WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/php_fopen_wrapper.c b/ext/standard/php_fopen_wrapper.c
+index 4287045511..7fe983cb33 100644
+--- a/ext/standard/php_fopen_wrapper.c
++++ b/ext/standard/php_fopen_wrapper.c
+@@ -246,13 +246,17 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			static int cli_in = 0;
+ 			fd = STDIN_FILENO;
+ 			if (cli_in) {
+-				fd = dup(fd);
++#ifndef WASM_WASI
++ 				fd = dup(fd);
++#endif // WASM_WASI
+ 			} else {
+ 				cli_in = 1;
+ 				file = stdin;
+ 			}
+ 		} else {
++#ifndef WASM_WASI
+ 			fd = dup(STDIN_FILENO);
++#endif // WASM_WASI
+ 		}
+ #ifdef PHP_WIN32
+ 		pipe_requested = 1;
+@@ -262,13 +266,17 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			static int cli_out = 0;
+ 			fd = STDOUT_FILENO;
+ 			if (cli_out++) {
+-				fd = dup(fd);
++#ifndef WASM_WASI
++ 				fd = dup(fd);
++#endif // WASM_WASI
+ 			} else {
+ 				cli_out = 1;
+ 				file = stdout;
+ 			}
+ 		} else {
++#ifndef WASM_WASI
+ 			fd = dup(STDOUT_FILENO);
++#endif // WASM_WASI
+ 		}
+ #ifdef PHP_WIN32
+ 		pipe_requested = 1;
+@@ -278,13 +286,17 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			static int cli_err = 0;
+ 			fd = STDERR_FILENO;
+ 			if (cli_err++) {
++#ifndef WASM_WASI
+ 				fd = dup(fd);
++#endif // WASM_WASI
+ 			} else {
+ 				cli_err = 1;
+ 				file = stderr;
+ 			}
+ 		} else {
++#ifndef WASM_WASI
+ 			fd = dup(STDERR_FILENO);
++#endif // WASM_WASI
+ 		}
+ #ifdef PHP_WIN32
+ 		pipe_requested = 1;
+@@ -317,7 +329,7 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			return NULL;
+ 		}
+ 
+-#if HAVE_UNISTD_H
++#if HAVE_UNISTD_H && !defined(WASM_WASI)
+ 		dtablesize = getdtablesize();
+ #else
+ 		dtablesize = INT_MAX;
+@@ -329,6 +341,7 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			return NULL;
+ 		}
+ 
++#ifndef WASM_WASI
+ 		fd = dup((int)fildes_ori);
+ 		if (fd == -1) {
+ 			php_stream_wrapper_log_error(wrapper, options,
+@@ -336,6 +349,7 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 				"[%d]: %s", fildes_ori, errno, strerror(errno));
+ 			return NULL;
+ 		}
++#endif // WASM_WASI
+ 	} else if (!strncasecmp(path, "filter/", 7)) {
+ 		/* Save time/memory when chain isn't specified */
+ 		if (strchr(mode, 'r') || strchr(mode, '+')) {
+diff --git a/main/fastcgi.c b/main/fastcgi.c
+index 9eb504bae7..66943b7c29 100644
+--- a/main/fastcgi.c
++++ b/main/fastcgi.c
+@@ -69,7 +69,9 @@ static int is_impersonate = 0;
+ # include <netinet/in.h>
+ # include <netinet/tcp.h>
+ # include <arpa/inet.h>
++# ifndef WASM_WASI
+ # include <netdb.h>
++# endif // WASM_WASI
+ # include <signal.h>
+ 
+ # if defined(HAVE_POLL_H) && defined(HAVE_POLL)
+@@ -431,6 +433,7 @@ static void fcgi_signal_handler(int signo)
+ 
+ static void fcgi_setup_signals(void)
+ {
++#ifndef WASM_WASI
+ 	struct sigaction new_sa, old_sa;
+ 
+ 	sigemptyset(&new_sa.sa_mask);
+@@ -442,6 +445,7 @@ static void fcgi_setup_signals(void)
+ 	if (old_sa.sa_handler == SIG_DFL) {
+ 		sigaction(SIGPIPE, &new_sa, NULL);
+ 	}
++#endif // WASM_WASI
+ }
+ #endif
+ 
+@@ -526,6 +530,8 @@ int fcgi_init(void)
+ 		} else {
+ 			return is_fastcgi = 0;
+ 		}
++#elif defined(WASM_WASI)
++		return is_fastcgi = 0;
+ #else
+ 		errno = 0;
+ 		if (getpeername(0, (struct sockaddr *)&sa, &len) != 0 && errno == ENOTCONN) {
+@@ -675,6 +681,7 @@ int fcgi_listen(const char *path, int backlog)
+ 
+ 	/* Prepare socket address */
+ 	if (tcp) {
++#ifndef WASM_WASI
+ 		memset(&sa.sa_inet, 0, sizeof(sa.sa_inet));
+ 		sa.sa_inet.sin_family = AF_INET;
+ 		sa.sa_inet.sin_port = htons(port);
+@@ -767,6 +774,7 @@ int fcgi_listen(const char *path, int backlog)
+ 	if (!tcp) {
+ 		chmod(path, 0777);
+ 	} else {
++#endif // WASM_WASI
+ 		char *ip = getenv("FCGI_WEB_SERVER_ADDRS");
+ 		char *cur, *end;
+ 		int n;
+@@ -1099,7 +1107,9 @@ static int fcgi_read_request(fcgi_request *req)
+ 			int on = 1;
+ # endif
+ 
++# ifndef WASM_WASI
+ 			setsockopt(req->fd, IPPROTO_TCP, TCP_NODELAY, (char*)&on, sizeof(on));
++# endif // WASM_WASI
+ 			req->nodelay = 1;
+ 		}
+ #endif
+@@ -1409,7 +1419,9 @@ int fcgi_accept_request(fcgi_request *req)
+ 					client_sa = sa;
+ 					if (req->fd >= 0 && !fcgi_is_allowed()) {
+ 						fcgi_log(FCGI_ERROR, "Connection disallowed: IP address '%s' has been dropped.", fcgi_get_last_client_ip());
++#ifndef WASM_WASI
+ 						closesocket(req->fd);
++#endif // WASM_WASI
+ 						req->fd = -1;
+ 						continue;
+ 					}
+diff --git a/main/fopen_wrappers.c b/main/fopen_wrappers.c
+index f6ce26e104..3d7c67b2de 100644
+--- a/main/fopen_wrappers.c
++++ b/main/fopen_wrappers.c
+@@ -52,7 +52,9 @@
+ #include <winsock2.h>
+ #else
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif // WASM_WASI
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+diff --git a/main/main.c b/main/main.c
+index b536504be7..8314a9b2d3 100644
+--- a/main/main.c
++++ b/main/main.c
+@@ -1398,6 +1398,7 @@ static ZEND_COLD void php_error_cb(int orig_type, zend_string *error_filename, c
+ /* {{{ php_get_current_user */
+ PHPAPI char *php_get_current_user(void)
+ {
++#ifndef WASM_WASI
+ 	zend_stat_t *pstat;
+ 
+ 	if (SG(request_info).current_user) {
+@@ -1460,6 +1461,9 @@ PHPAPI char *php_get_current_user(void)
+ 		return SG(request_info).current_user;
+ #endif
+ 	}
++#else
++	return "";
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/main/network.c b/main/network.c
+index 1ad7e370cc..97d036784d 100644
+--- a/main/network.c
++++ b/main/network.c
+@@ -54,7 +54,9 @@
+ 
+ #ifndef PHP_WIN32
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif // WASM_WASI
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+@@ -153,6 +155,7 @@ PHPAPI void php_network_freeaddresses(struct sockaddr **sal)
+  */
+ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct sockaddr ***sal, zend_string **error_string)
+ {
++#ifndef WASM_WASI
+ 	struct sockaddr **sap;
+ 	int n;
+ #if HAVE_GETADDRINFO
+@@ -275,6 +278,9 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
+ 
+ 	*sap = NULL;
+ 	return n;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -310,6 +316,7 @@ PHPAPI int php_network_connect_socket(php_socket_t sockfd,
+ 		zend_string **error_string,
+ 		int *error_code)
+ {
++#ifndef WASM_WASI
+ 	php_non_blocking_flags_t orig_flags;
+ 	int n;
+ 	int error = 0;
+@@ -403,6 +410,9 @@ static inline void sub_times(struct timeval a, struct timeval b, struct timeval
+ 		result->tv_sec++;
+ 		result->tv_usec -= 1000000L;
+ 	}
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -447,7 +457,11 @@ php_socket_t php_network_bind_socket_to_local_addr(const char *host, unsigned po
+ 		}
+ 
+ 		/* create a socket for this address */
++#ifndef WASM_WASI
+ 		sock = socket(sa->sa_family, socktype, 0);
++#else
++		sock = SOCK_ERR;
++#endif // WASM_WASI
+ 
+ 		if (sock == SOCK_ERR) {
+ 			continue;
+@@ -456,31 +470,45 @@ php_socket_t php_network_bind_socket_to_local_addr(const char *host, unsigned po
+ 		/* attempt to bind */
+ 
+ #ifdef SO_REUSEADDR
++#ifndef WASM_WASI
+ 		setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI
+ #endif
+ #ifdef IPV6_V6ONLY
+ 		if (sockopts & STREAM_SOCKOP_IPV6_V6ONLY) {
+ 			int ipv6_val = !!(sockopts & STREAM_SOCKOP_IPV6_V6ONLY_ENABLED);
++#ifndef WASM_WASI
+ 			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&ipv6_val, sizeof(sockoptval));
++#endif // WASM_WASI
+ 		}
+ #endif
+ #ifdef SO_REUSEPORT
+ 		if (sockopts & STREAM_SOCKOP_SO_REUSEPORT) {
++#ifndef WASM_WASI
+ 			setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI
+ 		}
+ #endif
+ #ifdef SO_BROADCAST
+ 		if (sockopts & STREAM_SOCKOP_SO_BROADCAST) {
++#ifndef WASM_WASI
+ 			setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI
+ 		}
+ #endif
+ #ifdef TCP_NODELAY
+ 		if (sockopts & STREAM_SOCKOP_TCP_NODELAY) {
++#ifndef WASM_WASI
+ 			setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI
+ 		}
+ #endif
+ 
++#ifndef WASM_WASI
+ 		n = bind(sock, sa, socklen);
++#else
++		n = SOCK_CONN_ERR;
++#endif // WASM_WASI
+ 
+ 		if (n != SOCK_CONN_ERR) {
+ 			goto bound;
+@@ -613,6 +641,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
+ 		socklen_t *addrlen
+ 		)
+ {
++#ifndef WASM_WASI
+ 	if (addr) {
+ 		*addr = emalloc(sl);
+ 		memcpy(*addr, sa, sl);
+@@ -670,6 +699,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
+ 		}
+ 
+ 	}
++#endif // WASM_WASI
+ }
+ 
+ PHPAPI int php_network_get_peer_name(php_socket_t sock,
+@@ -678,6 +708,7 @@ PHPAPI int php_network_get_peer_name(php_socket_t sock,
+ 		socklen_t *addrlen
+ 		)
+ {
++#ifndef WASM_WASI
+ 	php_sockaddr_storage sa;
+ 	socklen_t sl = sizeof(sa);
+ 	memset(&sa, 0, sizeof(sa));
+@@ -690,6 +721,9 @@ PHPAPI int php_network_get_peer_name(php_socket_t sock,
+ 		return 0;
+ 	}
+ 	return -1;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ 
+ PHPAPI int php_network_get_sock_name(php_socket_t sock,
+@@ -698,6 +732,7 @@ PHPAPI int php_network_get_sock_name(php_socket_t sock,
+ 		socklen_t *addrlen
+ 		)
+ {
++#ifndef WASM_WASI
+ 	php_sockaddr_storage sa;
+ 	socklen_t sl = sizeof(sa);
+ 	memset(&sa, 0, sizeof(sa));
+@@ -710,7 +745,9 @@ PHPAPI int php_network_get_sock_name(php_socket_t sock,
+ 		return 0;
+ 	}
+ 	return -1;
+-
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ 
+ 
+@@ -756,7 +793,9 @@ PHPAPI php_socket_t php_network_accept_incoming(php_socket_t srvsock,
+ 					);
+ 			if (tcp_nodelay) {
+ #ifdef TCP_NODELAY
++#ifndef WASM_WASI
+ 				setsockopt(clisock, IPPROTO_TCP, TCP_NODELAY, (char*)&tcp_nodelay, sizeof(tcp_nodelay));
++#endif // WASM_WASI
+ #endif
+ 			}
+ 		} else {
+@@ -873,7 +912,9 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
+ 					local_address_len = sizeof(struct sockaddr_in);
+ 					local_address.in4.sin_family = sa->sa_family;
+ 					local_address.in4.sin_port = htons(bindport);
++#ifndef WASM_WASI
+ 					memset(&(local_address.in4.sin_zero), 0, sizeof(local_address.in4.sin_zero));
++#endif // WASM_WASI
+ 				}
+ 			}
+ #if HAVE_IPV6 && HAVE_INET_PTON
+@@ -901,7 +942,9 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
+ 		{
+ 			int val = 1;
+ 			if (sockopts & STREAM_SOCKOP_SO_BROADCAST) {
++#ifndef WASM_WASI
+ 				setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char*)&val, sizeof(val));
++#endif // WASM_WASI
+ 			}
+ 		}
+ #endif
+@@ -910,7 +953,9 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
+ 		{
+ 			int val = 1;
+ 			if (sockopts & STREAM_SOCKOP_TCP_NODELAY) {
++#ifndef WASM_WASI
+ 				setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char*)&val, sizeof(val));
++#endif // WASM_WASI
+ 			}
+ 		}
+ #endif
+@@ -1316,6 +1361,7 @@ struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char *
+ #endif
+ 
+ PHPAPI struct hostent*	php_network_gethostbyname(const char *name) {
++#ifndef WASM_WASI
+ #if !defined(HAVE_GETHOSTBYNAME_R)
+ 	return gethostbyname(name);
+ #else
+@@ -1330,4 +1376,7 @@ PHPAPI struct hostent*	php_network_gethostbyname(const char *name) {
+ 
+ 	return gethostname_re(name, &FG(tmp_host_info), &FG(tmp_host_buf), &FG(tmp_host_buf_len));
+ #endif
++#else
++	return NULL;
++#endif // WASM_WASI
+ }
+diff --git a/main/php_open_temporary_file.c b/main/php_open_temporary_file.c
+index dcea783584..57bd337835 100644
+--- a/main/php_open_temporary_file.c
++++ b/main/php_open_temporary_file.c
+@@ -30,7 +30,9 @@
+ #include <sys/param.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+@@ -97,7 +99,7 @@ static int php_do_open_temporary_file(const char *path, const char *pfx, zend_st
+ 	char cwd[MAXPATHLEN];
+ 	cwd_state new_state;
+ 	int fd = -1;
+-#ifndef HAVE_MKSTEMP
++#if !defined(HAVE_MKSTEMP) || defined(WASM_WASI)
+ 	int open_flags = O_CREAT | O_TRUNC | O_RDWR
+ #ifdef PHP_WIN32
+ 		| _O_BINARY
+@@ -177,6 +179,8 @@ static int php_do_open_temporary_file(const char *path, const char *pfx, zend_st
+ 	free(pfxw);
+ #elif defined(HAVE_MKSTEMP)
+ 	fd = mkstemp(opened_path);
++#elif defined(WASM_WASI)
++	fd = VCWD_OPEN(opened_path, open_flags);
+ #else
+ 	if (mktemp(opened_path)) {
+ 		fd = VCWD_OPEN(opened_path, open_flags);
+diff --git a/main/php_syslog.c b/main/php_syslog.c
+index fa71a86313..68c7aac707 100644
+--- a/main/php_syslog.c
++++ b/main/php_syslog.c
+@@ -105,6 +105,7 @@ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
+ #else
+ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
+ {
++#ifndef WASM_WASI
+ 	zend_string *fbuf = NULL;
+ 	va_list args;
+ 
+@@ -124,6 +125,7 @@ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
+ 	php_syslog_str(priority, fbuf);
+ 
+ 	zend_string_release(fbuf);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ #endif
+diff --git a/main/streams/plain_wrapper.c b/main/streams/plain_wrapper.c
+index f8c3d89aef..6695a2f318 100644
+--- a/main/streams/plain_wrapper.c
++++ b/main/streams/plain_wrapper.c
+@@ -490,7 +490,9 @@ static int php_stdiop_close(php_stream *stream, int close_handle)
+ 		if (data->file) {
+ 			if (data->is_process_pipe) {
+ 				errno = 0;
++#ifndef WASM_WASI
+ 				ret = pclose(data->file);
++#endif
+ 
+ #ifdef HAVE_SYS_WAIT_H
+ 				if (WIFEXITED(ret)) {
+@@ -1292,13 +1294,18 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
+ 			zend_stat_t sb;
+ # if !defined(ZTS) && !defined(TSRM_WIN32)
+ 			/* not sure what to do in ZTS case, umask is not thread-safe */
++# ifndef WASM_WASI
+ 			int oldmask = umask(077);
++# else
++			int oldmask = 077;
++# endif // WASM_WASI
+ # endif
+ 			int success = 0;
+ 			if (php_copy_file(url_from, url_to) == SUCCESS) {
+ 				if (VCWD_STAT(url_from, &sb) == 0) {
+ 					success = 1;
+-#  ifndef TSRM_WIN32
++#  ifndef WASM_WASI
++#   ifndef TSRM_WIN32
+ 					/*
+ 					 * Try to set user and permission info on the target.
+ 					 * If we're not root, then some of these may fail.
+@@ -1321,7 +1328,8 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
+ 							}
+ 						}
+ 					}
+-#  endif
++#   endif
++#  endif // WASM_WASI
+ 					if (success) {
+ 						VCWD_UNLINK(url_from);
+ 					}
+@@ -1332,7 +1340,9 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
+ 				php_error_docref2(NULL, url_from, url_to, E_WARNING, "%s", strerror(errno));
+ 			}
+ #  if !defined(ZTS) && !defined(TSRM_WIN32)
++#  ifndef WASM_WASI
+ 			umask(oldmask);
++#  endif // WASM_WASI
+ #  endif
+ 			return success;
+ 		}
+@@ -1523,7 +1533,11 @@ static int php_plain_files_metadata(php_stream_wrapper *wrapper, const char *url
+ 			} else {
+ 				uid = (uid_t)*(long *)value;
+ 			}
++#ifndef WASM_WASI
+ 			ret = VCWD_CHOWN(url, uid, -1);
++#else
++			ret = 0;
++#endif // WASM_WASI
+ 			break;
+ 		case PHP_STREAM_META_GROUP:
+ 		case PHP_STREAM_META_GROUP_NAME:
+@@ -1535,12 +1549,20 @@ static int php_plain_files_metadata(php_stream_wrapper *wrapper, const char *url
+ 			} else {
+ 				gid = (gid_t)*(long *)value;
+ 			}
+-			ret = VCWD_CHOWN(url, -1, gid);
++#ifndef WASM_WASI
++			ret = VCWD_CHvOWN(url, -1, gid);
++#else
++			ret = 0;
++#endif // WASM_WASI
+ 			break;
+ #endif
+ 		case PHP_STREAM_META_ACCESS:
+ 			mode = (mode_t)*(zend_long *)value;
++#ifndef WASM_WASI
+ 			ret = VCWD_CHMOD(url, mode);
++#else
++			ret = 0;
++#endif // WASM_WASI
+ 			break;
+ 		default:
+ 			zend_value_error("Unknown option %d for stream_metadata", option);
+diff --git a/main/streams/xp_socket.c b/main/streams/xp_socket.c
+index b17eccf2ee..833a19ddda 100644
+--- a/main/streams/xp_socket.c
++++ b/main/streams/xp_socket.c
+@@ -219,7 +219,9 @@ static int php_sockop_close(php_stream *stream, int close_handle)
+ 				n = php_pollfd_for_ms(sock->socket, POLLOUT, 500);
+ 			} while (n == -1 && php_socket_errno() == EINTR);
+ #endif
++#ifndef WASM_WASI
+ 			closesocket(sock->socket);
++#endif // WASM_WASI
+ 			sock->socket = SOCK_ERR;
+ 		}
+ 
+@@ -256,8 +258,11 @@ static inline int sock_sendto(php_netstream_data_t *sock, const char *buf, size_
+ {
+ 	int ret;
+ 	if (addr) {
++#ifndef WASM_WASI
+ 		ret = sendto(sock->socket, buf, XP_SOCK_BUF_SIZE(buflen), flags, addr, XP_SOCK_BUF_SIZE(addrlen));
+-
++#else
++		ret = 0;
++#endif // WASM_WASI
+ 		return (ret == SOCK_CONN_ERR) ? -1 : ret;
+ 	}
+ #ifdef PHP_WIN32
+@@ -278,7 +283,11 @@ static inline int sock_recvfrom(php_netstream_data_t *sock, char *buf, size_t bu
+ 	if (want_addr) {
+ 		php_sockaddr_storage sa;
+ 		socklen_t sl = sizeof(sa);
++#ifndef WASM_WASI
+ 		ret = recvfrom(sock->socket, buf, XP_SOCK_BUF_SIZE(buflen), flags, (struct sockaddr*)&sa, &sl);
++#else
++		ret = 0;
++#endif // WASM_WASI
+ 		ret = (ret == SOCK_CONN_ERR) ? -1 : ret;
+ #ifdef PHP_WIN32
+ 		/* POSIX discards excess bytes without signalling failure; emulate this on Windows */
+@@ -337,6 +346,7 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 
+ 				if (sock->socket == -1) {
+ 					alive = 0;
++#ifndef WASM_WASI
+ 				} else if (php_pollfd_for(sock->socket, PHP_POLLREADABLE|POLLPRI, &tv) > 0) {
+ #ifdef PHP_WIN32
+ 					int ret;
+@@ -351,6 +361,7 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 						(0 > ret && err != EWOULDBLOCK && err != EAGAIN && err != EMSGSIZE)) { /* there was an unrecoverable error */
+ 						alive = 0;
+ 					}
++#endif // WASM_WASI
+ 				}
+ 				return alive ? PHP_STREAM_OPTION_RETURN_OK : PHP_STREAM_OPTION_RETURN_ERR;
+ 			}
+@@ -379,7 +390,11 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 
+ 			switch (xparam->op) {
+ 				case STREAM_XPORT_OP_LISTEN:
++#ifndef WASM_WASI
+ 					xparam->outputs.returncode = (listen(sock->socket, xparam->inputs.backlog) == 0) ?  0: -1;
++#else
++					xparam->outputs.returncode = 0;
++#endif // WASM_WASI
+ 					return PHP_STREAM_OPTION_RETURN_OK;
+ 
+ 				case STREAM_XPORT_OP_GET_NAME:
+@@ -401,7 +416,9 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 				case STREAM_XPORT_OP_SEND:
+ 					flags = 0;
+ 					if ((xparam->inputs.flags & STREAM_OOB) == STREAM_OOB) {
++#ifndef WASM_WASI
+ 						flags |= MSG_OOB;
++#endif // WASM_WASI
+ 					}
+ 					xparam->outputs.returncode = sock_sendto(sock,
+ 							xparam->inputs.buf, xparam->inputs.buflen,
+@@ -419,10 +436,14 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 				case STREAM_XPORT_OP_RECV:
+ 					flags = 0;
+ 					if ((xparam->inputs.flags & STREAM_OOB) == STREAM_OOB) {
++#ifndef WASM_WASI
+ 						flags |= MSG_OOB;
++#endif // WASM_WASI
+ 					}
+ 					if ((xparam->inputs.flags & STREAM_PEEK) == STREAM_PEEK) {
++#ifndef WASM_WASI
+ 						flags |= MSG_PEEK;
++#endif // WASM_WASI
+ 					}
+ 					xparam->outputs.returncode = sock_recvfrom(sock,
+ 							xparam->inputs.buf, xparam->inputs.buflen,
+@@ -556,6 +577,7 @@ static inline int parse_unix_address(php_stream_xport_param *xparam, struct sock
+ 	memset(unix_addr, 0, sizeof(*unix_addr));
+ 	unix_addr->sun_family = AF_UNIX;
+ 
++#ifndef WASM_WASI
+ 	/* we need to be binary safe on systems that support an abstract
+ 	 * namespace */
+ 	if (xparam->inputs.namelen >= sizeof(unix_addr->sun_path)) {
+@@ -571,6 +593,7 @@ static inline int parse_unix_address(php_stream_xport_param *xparam, struct sock
+ 	}
+ 
+ 	memcpy(unix_addr->sun_path, xparam->inputs.name, xparam->inputs.namelen);
++#endif // WASM_WASI
+ 
+ 	return 1;
+ }
+@@ -632,7 +655,9 @@ static inline int php_tcp_sockop_bind(php_stream *stream, php_netstream_data_t *
+ 	if (stream->ops == &php_stream_unix_socket_ops || stream->ops == &php_stream_unixdg_socket_ops) {
+ 		struct sockaddr_un unix_addr;
+ 
++#ifndef WASM_WASI
+ 		sock->socket = socket(PF_UNIX, stream->ops == &php_stream_unix_socket_ops ? SOCK_STREAM : SOCK_DGRAM, 0);
++#endif // WASM_WASI
+ 
+ 		if (sock->socket == SOCK_ERR) {
+ 			if (xparam->want_errortext) {
+@@ -645,8 +670,12 @@ static inline int php_tcp_sockop_bind(php_stream *stream, php_netstream_data_t *
+ 
+ 		parse_unix_address(xparam, &unix_addr);
+ 
++#ifndef WASM_WASI
+ 		return bind(sock->socket, (const struct sockaddr *)&unix_addr,
+ 			(socklen_t) XtOffsetOf(struct sockaddr_un, sun_path) + xparam->inputs.namelen);
++#else
++		return 0;
++#endif // WASM_WASI
+ 	}
+ #endif
+ 
+@@ -713,7 +742,9 @@ static inline int php_tcp_sockop_connect(php_stream *stream, php_netstream_data_
+ 	if (stream->ops == &php_stream_unix_socket_ops || stream->ops == &php_stream_unixdg_socket_ops) {
+ 		struct sockaddr_un unix_addr;
+ 
++#ifndef WASM_WASI
+ 		sock->socket = socket(PF_UNIX, stream->ops == &php_stream_unix_socket_ops ? SOCK_STREAM : SOCK_DGRAM, 0);
++#endif // WASM_WASI
+ 
+ 		if (sock->socket == SOCK_ERR) {
+ 			if (xparam->want_errortext) {
+@@ -725,7 +756,11 @@ static inline int php_tcp_sockop_connect(php_stream *stream, php_netstream_data_
+ 		parse_unix_address(xparam, &unix_addr);
+ 
+ 		ret = php_network_connect_socket(sock->socket,
++#ifndef WASM_WASI
+ 				(const struct sockaddr *)&unix_addr, (socklen_t) XtOffsetOf(struct sockaddr_un, sun_path) + xparam->inputs.namelen,
++#else
++				(const struct sockaddr *)&unix_addr, xparam->inputs.namelen,
++#endif // WASM_WASI
+ 				xparam->op == STREAM_XPORT_OP_CONNECT_ASYNC, xparam->inputs.timeout,
+ 				xparam->want_errortext ? &xparam->outputs.error_text : NULL,
+ 				&err);
+diff --git a/sapi/cgi/cgi_main.c b/sapi/cgi/cgi_main.c
+index 499a7932be..69e6de5364 100644
+--- a/sapi/cgi/cgi_main.c
++++ b/sapi/cgi/cgi_main.c
+@@ -43,7 +43,9 @@
+ # include <unistd.h>
+ #endif
+ 
++#ifndef WASM_WASI
+ #include <signal.h>
++#endif // WASM_WASI
+ 
+ #include <locale.h>
+ 
+@@ -94,10 +96,12 @@ int __riscosify_control = __RISCOSIFY_STRICT_UNIX_SPECS;
+ # include "valgrind/callgrind.h"
+ #endif
+ 
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ /* XXX this will need to change later when threaded fastcgi is implemented.  shane */
+ struct sigaction act, old_term, old_quit, old_int;
+ #endif
++#endif // WASM_WASI
+ 
+ static void (*php_php_import_environment_variables)(zval *array_ptr);
+ 
+@@ -1458,6 +1462,7 @@ static void init_request_info(fcgi_request *request)
+  */
+ void fastcgi_cleanup(int signal)
+ {
++#ifndef WASM_WASI
+ #ifdef DEBUG_FASTCGI
+ 	fprintf(stderr, "FastCGI shutdown, pid %d\n", getpid());
+ #endif
+@@ -1472,6 +1477,9 @@ void fastcgi_cleanup(int signal)
+ 	} else {
+ 		exit(0);
+ 	}
++#else
++	exit(0);
++#endif // WASM_WASI
+ }
+ #else
+ BOOL WINAPI fastcgi_cleanup(DWORD sig)
+@@ -1767,7 +1775,9 @@ int main(int argc, char *argv[])
+ # endif
+ #endif
+ 
++#ifndef WASM_WASI
+ 	zend_signal_startup();
++#endif // WASM_WASI
+ 
+ #ifdef ZTS
+ 	ts_allocate_id(&php_cgi_globals_id, sizeof(php_cgi_globals_struct), (ts_allocate_ctor) php_cgi_globals_ctor, NULL);
+@@ -1897,6 +1907,7 @@ int main(int argc, char *argv[])
+ 		return FAILURE;
+ 	}
+ 
++#ifndef WASM_WASI
+ 	/* check force_cgi after startup, so we have proper output */
+ 	if (cgi && CGIG(force_redirect)) {
+ 		/* Apache will generate REDIRECT_STATUS,
+@@ -1937,6 +1948,7 @@ consult the installation file that came with this distribution, or visit \n\
+ 			return FAILURE;
+ 		}
+ 	}
++#endif // WASM_WASI
+ 
+ #ifndef HAVE_ATTRIBUTE_WEAK
+ 	fcgi_set_logger(fcgi_log);
+@@ -2013,12 +2025,17 @@ consult the installation file that came with this distribution, or visit \n\
+ 			pid_t pid;
+ 
+ 			/* Create a process group for us & children */
++#ifndef WASM_WASI
+ 			setsid();
+ 			pgroup = getpgrp();
++#else
++			pgroup = 0;
++#endif // WASM_WASI
+ #ifdef DEBUG_FASTCGI
+ 			fprintf(stderr, "Process group %d\n", pgroup);
+ #endif
+ 
++#ifndef WASM_WASI
+ 			/* Set up handler to kill children upon exit */
+ 			act.sa_flags = 0;
+ 			act.sa_handler = fastcgi_cleanup;
+@@ -2029,6 +2046,7 @@ consult the installation file that came with this distribution, or visit \n\
+ 				perror("Can't set signals");
+ 				exit(1);
+ 			}
++#endif // WASM_WASI
+ 
+ 			if (fcgi_in_shutdown()) {
+ 				goto parent_out;
+@@ -2039,7 +2057,11 @@ consult the installation file that came with this distribution, or visit \n\
+ #ifdef DEBUG_FASTCGI
+ 					fprintf(stderr, "Forking, %d running\n", running);
+ #endif
++#ifndef WASM_WASI
+ 					pid = fork();
++#else
++					pid = 1;
++#endif // WASM_WASI
+ 					switch (pid) {
+ 					case 0:
+ 						/* One of the children.
+@@ -2048,11 +2070,13 @@ consult the installation file that came with this distribution, or visit \n\
+ 						 */
+ 						parent = 0;
+ 
++#ifndef WASM_WASI
+ 						/* don't catch our signals */
+ 						sigaction(SIGTERM, &old_term, 0);
+ 						sigaction(SIGQUIT, &old_quit, 0);
+ 						sigaction(SIGINT,  &old_int,  0);
+ 						zend_signal_init();
++#endif // WASM_WASI
+ 						break;
+ 					case -1:
+ 						perror("php (pre-forking)");
+@@ -2071,12 +2095,14 @@ consult the installation file that came with this distribution, or visit \n\
+ #endif
+ 					parent_waiting = 1;
+ 					while (1) {
++#ifndef WASM_WASI
+ 						if (wait(&status) >= 0) {
+ 							running--;
+ 							break;
+ 						} else if (exit_signal) {
+ 							break;
+ 						}
++#endif // WASM_WASI
+ 					}
+ 					if (exit_signal) {
+ #if 0
+diff --git a/sapi/fpm/fpm/fpm_unix.c b/sapi/fpm/fpm/fpm_unix.c
+index ed5b66294f..adf3adb75f 100644
+--- a/sapi/fpm/fpm/fpm_unix.c
++++ b/sapi/fpm/fpm/fpm_unix.c
+@@ -9,7 +9,9 @@
+ #include <unistd.h>
+ #include <sys/types.h>
+ #include <pwd.h>
++#ifdef HAVE_GRP_H
+ #include <grp.h>
++#endif
+ 
+ #ifdef HAVE_PRCTL
+ #include <sys/prctl.h>
+diff --git a/sapi/litespeed/lsapilib.c b/sapi/litespeed/lsapilib.c
+index 2208bbd47b..26d0d307b1 100644
+--- a/sapi/litespeed/lsapilib.c
++++ b/sapi/litespeed/lsapilib.c
+@@ -65,7 +65,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <sys/time.h>
+ #include <sys/uio.h>
+ #include <sys/wait.h>
++#ifdef HAVE_GRP_H
+ #include <grp.h>
++#endif
+ #include <pwd.h>
+ #include <time.h>
+ #include <unistd.h>
+-- 
+2.38.1
+

--- a/php/php-8.1.11/patches/0002-feat-Incapacitate-fibers-when-compiling-for-WASI.patch
+++ b/php/php-8.1.11/patches/0002-feat-Incapacitate-fibers-when-compiling-for-WASI.patch
@@ -1,0 +1,84 @@
+From e2d0dffab5afbe108e45220c584a20f84ac40f21 Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Tue, 3 Jan 2023 17:02:38 +0200
+Subject: [PATCH 2/2] feat: Incapacitate fibers when compiling for WASI
+
+
+  26.2% Zend/
+diff --git a/Zend/zend_fibers.c b/Zend/zend_fibers.c
+index 5f692bf1..f7724d0b 100644
+--- a/Zend/zend_fibers.c
++++ b/Zend/zend_fibers.c
+@@ -344,12 +344,14 @@ ZEND_API bool zend_fiber_init_context(zend_fiber_context *context, void *kind, z
+ 	makecontext(handle, (void (*)(void)) zend_fiber_trampoline, 0);
+ 
+ 	context->handle = handle;
+-#else
++#elif !defined(__wasi__)
+ 	// Stack grows down, calculate the top of the stack. make_fcontext then shifts pointer to lower 16-byte boundary.
+ 	void *stack = (void *) ((uintptr_t) context->stack->pointer + context->stack->size);
+ 
+ 	context->handle = make_fcontext(stack, context->stack->size, zend_fiber_trampoline);
+ 	ZEND_ASSERT(context->handle != NULL && "make_fcontext() never returns NULL");
++#else
++	return false;
+ #endif
+ 
+ 	context->kind = kind;
+@@ -420,16 +422,18 @@ ZEND_API void zend_fiber_switch_context(zend_fiber_transfer *transfer)
+ 
+ 	/* Copy transfer struct because it might live on the other fiber's stack that will eventually be destroyed. */
+ 	*transfer = *transfer_data;
+-#else
++#elif !defined(__wasi__)
+ 	boost_context_data data = jump_fcontext(to->handle, transfer);
+ 
+ 	/* Copy transfer struct because it might live on the other fiber's stack that will eventually be destroyed. */
+ 	*transfer = *data.transfer;
++#else
++	return;
+ #endif
+ 
+ 	to = transfer->context;
+ 
+-#ifndef ZEND_FIBER_UCONTEXT
++#if !defined(ZEND_FIBER_UCONTEXT) && !defined(__wasi__)
+ 	/* Get the context that resumed us and update its handle to allow for symmetric coroutines. */
+ 	to->handle = data.handle;
+ #endif
+diff --git a/configure.ac b/configure.ac
+index ee2d2481..2295d025 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -197,6 +197,9 @@ label2:
+ fi
+ PHP_SUBST(RE2C_FLAGS)
+ 
++dnl Check if __wasi__ is defined by the compiler
++AC_CHECK_DECLS([__wasi__])
++
+ dnl Platform-specific compile settings.
+ dnl ----------------------------------------------------------------------------
+ 
+@@ -1249,11 +1252,13 @@ else
+   if test "$fiber_os" = 'mac'; then
+     AC_DEFINE([_XOPEN_SOURCE], 1, [ ])
+   fi
+-  AC_CHECK_HEADER(ucontext.h, [
+-    AC_DEFINE([ZEND_FIBER_UCONTEXT], 1, [ ])
+-  ], [
+-       AC_MSG_ERROR([fibers not available on this platform])
+-  ])
++  if test "$ac_cv_have_decl___wasi__" != "yes"; then
++    AC_CHECK_HEADER(ucontext.h, [
++      AC_DEFINE([ZEND_FIBER_UCONTEXT], 1, [ ])
++    ], [
++        AC_MSG_ERROR([fibers not available on this platform])
++    ])
++  fi
+ fi
+ 
+ LIBZEND_BASIC_CHECKS
+-- 
+2.38.1
+

--- a/php/php-8.1.11/wl-build-deps.sh
+++ b/php/php-8.1.11/wl-build-deps.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+if [ "${BASH_SOURCE-}" = "$0" ]; then
+    echo "You must source this script to add to CFLAGS and LDFLAGS: \$ source $0" >&2
+    return
+fi
+
+logStatus "Building dependencies... "
+
+### sqlite3
+$WASMLABS_MAKE ${WASMLABS_REPO_ROOT}/libs/sqlite/version-3.39.2 || exit 1
+
+export CFLAGS_DEPENDENCIES="-I${WASMLABS_OUTPUT_BASE}/sqlite/version-3.39.2/include ${CFLAGS_DEPENDENCIES}"
+export LDFLAGS_DEPENDENCIES="-L${WASMLABS_OUTPUT_BASE}/sqlite/version-3.39.2/lib ${LDFLAGS_DEPENDENCIES}"

--- a/php/php-8.1.11/wl-build.sh
+++ b/php/php-8.1.11/wl-build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+# export CFLAGS_CONFIG="-O3 -g"
+export CFLAGS_CONFIG="-O2"
+
+########## Setup the wasi related flags #############
+export CFLAGS_WASI="--sysroot=${WASI_SYSROOT} -D_WASI_EMULATED_GETPID -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS"
+export LDFLAGS_WASI="--sysroot=${WASI_SYSROOT} -lwasi-emulated-getpid -lwasi-emulated-signal -lwasi-emulated-process-clocks"
+
+########## Setup the libsql related flags #############
+export CFLAGS_SQLITE='-DSQLITE_OMIT_LOAD_EXTENSION=1'
+export LDFLAGS_SQLITE='-lsqlite3'
+
+########## Setup the flags for php #############
+export CFLAGS_PHP='-D_POSIX_SOURCE=1 -D_GNU_SOURCE=1 -DHAVE_FORK=0 -DWASM_WASI'
+
+# We need to add LDFLAGS ot CFLAGS because autoconf compiles(+links) to binary when checking stuff
+export LDFLAGS="${LDFLAGS_WASI} ${LDFLAGS_DEPENDENCIES} ${LDFLAGS_SQLITE}"
+export CFLAGS="${CFLAGS_CONFIG} ${CFLAGS_WASI} ${CFLAGS_SQLITE} ${CFLAGS_DEPENDENCIES} ${CFLAGS_PHP} ${LDFLAGS}"
+
+cd "${WASMLABS_CHECKOUT_PATH}"
+
+logStatus "Generating configure script... "
+./buildconf --force || exit 1
+
+export PHP_CONFIGURE=' --without-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite --disable-fiber-asm'
+
+logStatus "Configuring build with '${PHP_CONFIGURE}'... "
+./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${PHP_CONFIGURE} || exit 1
+
+logStatus "Building php-cgi... "
+make cgi  || exit 1
+
+logStatus "Preparing artifacts... "
+mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
+
+cp sapi/cgi/php-cgi ${WASMLABS_OUTPUT}/bin/ || exit 1
+
+logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/php/php-8.1.11/wl-tag.sh
+++ b/php/php-8.1.11/wl-tag.sh
@@ -1,0 +1,1 @@
+export WLR_TAG="php/8.1.11"

--- a/php/php-8.1.11/wl-test.sh
+++ b/php/php-8.1.11/wl-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+if ! [ -x "$(command -v php)" ]
+then
+    echo "Native php is required in PATH on the host to act as orchestrator for php.wasm tests!"
+    exit 1
+fi
+
+if [ -f "${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}" ]
+then
+    export WASMLABS_TESTED_MODULE="${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}"
+else
+    export WASMLABS_TESTED_MODULE="${WASMLABS_OUTPUT}/bin/php-cgi${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}"
+fi
+
+if ! [ -x "${WASMLABS_TESTED_MODULE}" ]
+then
+    echo "WASM module not found at '${WASMLABS_TESTED_MODULE}'"
+    exit 1
+fi
+
+cd "${WASMLABS_CHECKOUT_PATH}"
+echo "Calling 'WASMLABS_TESTED_MODULE=${WASMLABS_TESTED_MODULE} php -f run-tests.php -- -p ${WASMLABS_TEST_RUNTIME_WRAPPER} -j6' to run tests..."
+php -f run-tests.php -- -p ${WASMLABS_TEST_RUNTIME_WRAPPER} -j6 \
+    tests/lang \
+    tests/output \
+    tests/strings \
+    Zend/tests/fibers
+
+# tests/ \
+# ext/standard/tests \

--- a/php/php-8.2.0/patches/0001-Initial-port-of-the-php-7.4.32-patch-for-php-8.2.11.patch
+++ b/php/php-8.2.0/patches/0001-Initial-port-of-the-php-7.4.32-patch-for-php-8.2.11.patch
@@ -1,0 +1,2042 @@
+From 6e123de32e76dc3e1f91cbf46fae3bc9f302c3a2 Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Tue, 8 Nov 2022 16:07:48 +0200
+Subject: [PATCH 1/5] Initial port of the php 7.4.32 patch for php 8.2.11
+
+  19.8% Zend/
+  16.0% ext/posix/
+  24.1% ext/standard/
+  14.4% main/streams/
+  17.2% main/
+   5.5% sapi/cgi/
+
+  19.4% Zend/
+  15.7% ext/posix/
+  25.4% ext/standard/
+  14.1% main/streams/
+  16.9% main/
+   5.4% sapi/cgi/
+diff --git a/Zend/zend.c b/Zend/zend.c
+index c6a5f7f91c..60818b6ede 100644
+--- a/Zend/zend.c
++++ b/Zend/zend.c
+@@ -780,7 +780,9 @@ static void executor_globals_ctor(zend_executor_globals *executor_globals) /* {{
+ #endif
+ 	executor_globals->saved_fpu_cw_ptr = NULL;
+ 	executor_globals->active = 0;
++#ifndef WASM_WASI
+ 	executor_globals->bailout = NULL;
++#endif // WASM_WASI
+ 	executor_globals->error_handling  = EH_NORMAL;
+ 	executor_globals->exception_class = NULL;
+ 	executor_globals->exception = NULL;
+@@ -1158,6 +1160,7 @@ ZEND_COLD void zenderror(const char *error) /* {{{ */
+ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32_t lineno) /* {{{ */
+ {
+ 
++#ifndef WASM_WASI
+ 	if (!EG(bailout)) {
+ 		zend_output_debug_string(1, "%s(%d) : Bailed out without a bailout address!", filename, lineno);
+ 		exit(-1);
+@@ -1168,6 +1171,7 @@ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32
+ 	CG(in_compilation) = 0;
+ 	EG(current_execute_data) = NULL;
+ 	LONGJMP(*EG(bailout), FAILURE);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/Zend/zend.h b/Zend/zend.h
+index fd7d33f46f..f2b161d352 100644
+--- a/Zend/zend.h
++++ b/Zend/zend.h
+@@ -254,6 +254,7 @@ typedef size_t (*zend_write_func_t)(const char *str, size_t str_length);
+ 
+ #define zend_bailout()		_zend_bailout(__FILE__, __LINE__)
+ 
++#ifndef WASM_WASI
+ #define zend_try												\
+ 	{															\
+ 		JMP_BUF *__orig_bailout = EG(bailout);					\
+@@ -270,6 +271,19 @@ typedef size_t (*zend_write_func_t)(const char *str, size_t str_length);
+ 	}
+ #define zend_first_try		EG(bailout)=NULL;	zend_try
+ 
++#else // WASM_WASI
++#define zend_try												\
++	{															\
++		if (1) {
++#define zend_catch												\
++		} else {
++#define zend_end_try()											\
++		}														\
++	}
++#define zend_first_try		zend_try
++#endif // WASM_WASI
++
++
+ BEGIN_EXTERN_C()
+ void zend_startup(zend_utility_functions *utility_functions);
+ void zend_shutdown(void);
+diff --git a/Zend/zend_alloc.c b/Zend/zend_alloc.c
+index d0e28dca0d..5e67345c76 100644
+--- a/Zend/zend_alloc.c
++++ b/Zend/zend_alloc.c
+@@ -80,7 +80,7 @@
+ #include <fcntl.h>
+ #include <errno.h>
+ 
+-#ifndef _WIN32
++#if !defined(_WIN32) && HAVE_MMAP
+ # include <sys/mman.h>
+ # ifndef MAP_ANON
+ #  ifdef MAP_ANONYMOUS
+@@ -422,6 +422,8 @@ static void *zend_mm_mmap_fixed(void *addr, size_t size)
+ {
+ #ifdef _WIN32
+ 	return VirtualAlloc(addr, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
++#elif ! HAVE_MMAP
++	return NULL;
+ #else
+ 	int flags = MAP_PRIVATE | MAP_ANON;
+ #if defined(MAP_EXCL)
+@@ -462,6 +464,10 @@ static void *zend_mm_mmap(size_t size)
+ 		return NULL;
+ 	}
+ 	return ptr;
++#elif ! HAVE_MMAP
++	void* ptr = malloc(size);
++	memset(ptr, 0, size);
++	return ptr;
+ #else
+ 	void *ptr;
+ 
+@@ -503,6 +509,8 @@ static void zend_mm_munmap(void *addr, size_t size)
+ 		stderr_last_error("VirtualFree() failed");
+ #endif
+ 	}
++#elif ! HAVE_MMAP
++	free(addr);
+ #else
+ 	if (munmap(addr, size) != 0) {
+ #if ZEND_MM_ERROR
+@@ -688,6 +696,11 @@ static zend_always_inline void zend_mm_hugepage(void* ptr, size_t size)
+ 
+ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
+ {
++#if ! HAVE_MMAP
++	void* ptr = aligned_alloc(alignment, size);
++	memset(ptr, 0, size);
++	return ptr;
++#else
+ 	void *ptr = zend_mm_mmap(size);
+ 
+ 	if (ptr == NULL) {
+@@ -730,6 +743,7 @@ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
+ #endif
+ 		return ptr;
+ 	}
++#endif
+ }
+ 
+ static void *zend_mm_chunk_alloc(zend_mm_heap *heap, size_t size, size_t alignment)
+@@ -2899,7 +2913,7 @@ ZEND_API void start_memory_manager(void)
+ #else
+ 	alloc_globals_ctor(&alloc_globals);
+ #endif
+-#ifndef _WIN32
++#if !defined(_WIN32) && HAVE_MMAP
+ #  if defined(_SC_PAGESIZE)
+ 	REAL_PAGE_SIZE = sysconf(_SC_PAGESIZE);
+ #  elif defined(_SC_PAGE_SIZE)
+diff --git a/Zend/zend_fibers.c b/Zend/zend_fibers.c
+index 0bb45d1c3d..0bc4e0c676 100644
+--- a/Zend/zend_fibers.c
++++ b/Zend/zend_fibers.c
+@@ -37,7 +37,7 @@
+ # include <ucontext.h>
+ #endif
+ 
+-#ifndef ZEND_WIN32
++#if !defined(ZEND_WIN32) && HAVE_MMAP
+ # include <unistd.h>
+ # include <sys/mman.h>
+ # include <limits.h>
+@@ -92,7 +92,9 @@ typedef struct _zend_fiber_vm_state {
+ 	zend_execute_data *current_execute_data;
+ 	int error_reporting;
+ 	uint32_t jit_trace_num;
++#ifndef WASM_WASI
+ 	JMP_BUF *bailout;
++#endif // WASM_WASI
+ 	zend_fiber *active_fiber;
+ } zend_fiber_vm_state;
+ 
+@@ -105,7 +107,9 @@ static zend_always_inline void zend_fiber_capture_vm_state(zend_fiber_vm_state *
+ 	state->current_execute_data = EG(current_execute_data);
+ 	state->error_reporting = EG(error_reporting);
+ 	state->jit_trace_num = EG(jit_trace_num);
++#ifndef WASM_WASI
+ 	state->bailout = EG(bailout);
++#endif // WASM_WASI
+ 	state->active_fiber = EG(active_fiber);
+ }
+ 
+@@ -118,7 +122,9 @@ static zend_always_inline void zend_fiber_restore_vm_state(zend_fiber_vm_state *
+ 	EG(current_execute_data) = state->current_execute_data;
+ 	EG(error_reporting) = state->error_reporting;
+ 	EG(jit_trace_num) = state->jit_trace_num;
++#ifndef WASM_WASI
+ 	EG(bailout) = state->bailout;
++#endif // WASM_WASI
+ 	EG(active_fiber) = state->active_fiber;
+ }
+ 
+@@ -204,6 +210,8 @@ static zend_fiber_stack *zend_fiber_stack_allocate(size_t size)
+ 		return NULL;
+ 	}
+ # endif
++#elif defined(WASM_WASI)
++	pointer = malloc(alloc_size);
+ #else
+ 	pointer = mmap(NULL, alloc_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+ 
+@@ -253,6 +261,8 @@ static void zend_fiber_stack_free(zend_fiber_stack *stack)
+ 
+ #ifdef ZEND_WIN32
+ 	VirtualFree(pointer, 0, MEM_RELEASE);
++#elif defined(WASM_WASI)
++	free(pointer);
+ #else
+ 	munmap(pointer, stack->size + ZEND_FIBER_GUARD_PAGES * page_size);
+ #endif
+diff --git a/Zend/zend_globals.h b/Zend/zend_globals.h
+index 17469fab0c..27868fb512 100644
+--- a/Zend/zend_globals.h
++++ b/Zend/zend_globals.h
+@@ -21,7 +21,9 @@
+ #define ZEND_GLOBALS_H
+ 
+ 
++#ifndef WASM_WASI
+ #include <setjmp.h>
++#endif
+ 
+ #include "zend_globals_macros.h"
+ 
+@@ -157,7 +159,9 @@ struct _zend_executor_globals {
+ 
+ 	HashTable included_files;	/* files already included */
+ 
++#ifndef WASM_WASI
+ 	JMP_BUF *bailout;
++#endif
+ 
+ 	int error_reporting;
+ 	int exit_status;
+diff --git a/Zend/zend_types.h b/Zend/zend_types.h
+index df64541749..4059003720 100644
+--- a/Zend/zend_types.h
++++ b/Zend/zend_types.h
+@@ -1446,5 +1446,15 @@ static zend_always_inline uint32_t zval_delref_p(zval* pz) {
+ #define ZVAL_COPY_OR_DUP_PROP(z, v) \
+ 	do { ZVAL_COPY_OR_DUP(z, v); Z_PROP_FLAG_P(z) = Z_PROP_FLAG_P(v); } while (0)
+ 
++#ifdef WASM_WASI
++#define	LOG_EMERG	0	/* system is unusable */
++#define	LOG_ALERT	1	/* action must be taken immediately */
++#define	LOG_CRIT	2	/* critical conditions */
++#define	LOG_ERR		3	/* error conditions */
++#define	LOG_WARNING	4	/* warning conditions */
++#define	LOG_NOTICE	5	/* normal but significant condition */
++#define	LOG_INFO	6	/* informational */
++#define	LOG_DEBUG	7	/* debug-level messages */
++#endif // WASM_WASI
+ 
+ #endif /* ZEND_TYPES_H */
+diff --git a/Zend/zend_virtual_cwd.c b/Zend/zend_virtual_cwd.c
+index 64fc165174..2a3c5c7d42 100644
+--- a/Zend/zend_virtual_cwd.c
++++ b/Zend/zend_virtual_cwd.c
+@@ -1400,6 +1400,8 @@ CWD_API int virtual_chmod(const char *filename, mode_t mode) /* {{{ */
+ 		}
+ 		ret = php_win32_ioutil_chmod(new_state.cwd, mode);
+ 	}
++#elif defined WASM_WASI
++	ret = 0;
+ #else
+ 	ret = chmod(new_state.cwd, mode);
+ #endif
+@@ -1428,7 +1430,11 @@ CWD_API int virtual_chown(const char *filename, uid_t owner, gid_t group, int li
+ 		ret = -1;
+ #endif
+ 	} else {
++#ifndef WASM_WASI
+ 		ret = chown(new_state.cwd, owner, group);
++#else
++		ret = 0;
++#endif // WASM_WASI
+ 	}
+ 
+ 	CWD_STATE_FREE_ERR(&new_state);
+@@ -1706,8 +1712,11 @@ CWD_API FILE *virtual_popen(const char *command, const char *type) /* {{{ */
+ 	*ptr++ = ' ';
+ 
+ 	memcpy(ptr, command, command_length+1);
++#ifndef WASM_WASI
+ 	retval = popen(command_line, type);
+-
++#else
++	retval = 0;
++#endif // WASM_WASI
+ 	efree(command_line);
+ 	return retval;
+ }
+diff --git a/ext/fileinfo/libmagic/compress.c b/ext/fileinfo/libmagic/compress.c
+index 85d0b2938e..0129c20341 100644
+--- a/ext/fileinfo/libmagic/compress.c
++++ b/ext/fileinfo/libmagic/compress.c
+@@ -453,7 +453,7 @@ file_pipe2file(struct magic_set *ms, int fd, const void *startbuf,
+ 	int tfd;
+ 
+ 	(void)strlcpy(buf, "/tmp/file.XXXXXX", sizeof buf);
+-#ifndef HAVE_MKSTEMP
++#if !defined(HAVE_MKSTEMP) && !defined(WASM_WASI)
+ 	{
+ 		char *ptr = mktemp(buf);
+ 		tfd = open(ptr, O_RDWR|O_TRUNC|O_EXCL|O_CREAT, 0600);
+diff --git a/ext/fileinfo/libmagic/fsmagic.c b/ext/fileinfo/libmagic/fsmagic.c
+index a1b18d479f..ff43d7bebc 100644
+--- a/ext/fileinfo/libmagic/fsmagic.c
++++ b/ext/fileinfo/libmagic/fsmagic.c
+@@ -167,6 +167,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, zend_stat_t *sb)
+ # endif
+ #endif
+ 
++#ifndef WASM_WASI
+ #ifdef	S_IFIFO
+ 	case S_IFIFO:
+ 		if((ms->flags & MAGIC_DEVICES) != 0)
+@@ -179,6 +180,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, zend_stat_t *sb)
+ 			return -1;
+ 		break;
+ #endif
++#endif // WASM_WASI
+ #ifdef	S_IFDOOR
+ 	case S_IFDOOR:
+ 		if (mime) {
+diff --git a/ext/pdo_sqlite/sqlite_statement.c b/ext/pdo_sqlite/sqlite_statement.c
+index 90de059a3b..2e83f01af6 100644
+--- a/ext/pdo_sqlite/sqlite_statement.c
++++ b/ext/pdo_sqlite/sqlite_statement.c
+@@ -32,7 +32,9 @@ static int pdo_sqlite_stmt_dtor(pdo_stmt_t *stmt)
+ 	pdo_sqlite_stmt *S = (pdo_sqlite_stmt*)stmt->driver_data;
+ 
+ 	if (S->stmt) {
++#ifndef WASM_WASI
+ 		sqlite3_finalize(S->stmt);
++#endif
+ 		S->stmt = NULL;
+ 	}
+ 	efree(S);
+diff --git a/ext/posix/posix.c b/ext/posix/posix.c
+index ed7a93c540..49806f2cb4 100644
+--- a/ext/posix/posix.c
++++ b/ext/posix/posix.c
+@@ -37,8 +37,10 @@
+ #include <signal.h>
+ #include <sys/times.h>
+ #include <errno.h>
++#ifndef WASM_WASI
+ #include <grp.h>
+ #include <pwd.h>
++#endif // WASM_WASI
+ #ifdef HAVE_SYS_MKDEV_H
+ # include <sys/mkdev.h>
+ #endif
+@@ -123,6 +125,7 @@ ZEND_GET_MODULE(posix)
+ 
+ PHP_FUNCTION(posix_kill)
+ {
++#ifndef WASM_WASI
+ 	zend_long pid, sig;
+ 
+ 	ZEND_PARSE_PARAMETERS_START(2, 2)
+@@ -134,7 +137,7 @@ PHP_FUNCTION(posix_kill)
+ 		POSIX_G(last_error) = errno;
+ 		RETURN_FALSE;
+ 	}
+-
++#endif // WASM_WASI
+ 	RETURN_TRUE;
+ }
+ /* }}} */
+@@ -142,56 +145,88 @@ PHP_FUNCTION(posix_kill)
+ /* {{{ Get the current process id (POSIX.1, 4.1.1) */
+ PHP_FUNCTION(posix_getpid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getpid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Get the parent process id (POSIX.1, 4.1.1) */
+ PHP_FUNCTION(posix_getppid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getppid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Get the current user id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_getuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Get the current group id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_getgid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getgid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Get the current effective user id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_geteuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(geteuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Get the current effective group id (POSIX.1, 4.2.1) */
+ PHP_FUNCTION(posix_getegid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getegid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Set user id (POSIX.1, 4.2.2) */
+ PHP_FUNCTION(posix_setuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(setuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Set group id (POSIX.1, 4.2.2) */
+ PHP_FUNCTION(posix_setgid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(setgid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -199,7 +234,11 @@ PHP_FUNCTION(posix_setgid)
+ #ifdef HAVE_SETEUID
+ PHP_FUNCTION(posix_seteuid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(seteuid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ #endif
+ /* }}} */
+@@ -208,7 +247,11 @@ PHP_FUNCTION(posix_seteuid)
+ #ifdef HAVE_SETEGID
+ PHP_FUNCTION(posix_setegid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_SINGLE_ARG_FUNC(setegid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ #endif
+ /* }}} */
+@@ -268,7 +311,11 @@ PHP_FUNCTION(posix_getlogin)
+ /* {{{ Get current process group id (POSIX.1, 4.3.1) */
+ PHP_FUNCTION(posix_getpgrp)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(getpgrp);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -276,7 +323,11 @@ PHP_FUNCTION(posix_getpgrp)
+ #ifdef HAVE_SETSID
+ PHP_FUNCTION(posix_setsid)
+ {
++#ifndef WASM_WASI
+ 	PHP_POSIX_RETURN_LONG_FUNC(setsid);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ #endif
+ /* }}} */
+@@ -284,6 +335,7 @@ PHP_FUNCTION(posix_setsid)
+ /* {{{ Set process group id for job control (POSIX.1, 4.3.3) */
+ PHP_FUNCTION(posix_setpgid)
+ {
++#ifndef WASM_WASI
+ 	zend_long pid, pgid;
+ 
+ 	ZEND_PARSE_PARAMETERS_START(2, 2)
+@@ -295,6 +347,7 @@ PHP_FUNCTION(posix_setpgid)
+ 		POSIX_G(last_error) = errno;
+ 		RETURN_FALSE;
+ 	}
++#endif // WASM_WASI
+ 
+ 	RETURN_TRUE;
+ }
+@@ -462,6 +515,7 @@ PHP_FUNCTION(posix_ttyname)
+ 		default:
+ 			fd = zval_get_long(z_fd);
+ 	}
++#ifndef WASM_WASI
+ #if defined(ZTS) && defined(HAVE_TTYNAME_R) && defined(_SC_TTY_NAME_MAX)
+ 	buflen = sysconf(_SC_TTY_NAME_MAX);
+ 	if (buflen < 1) {
+@@ -482,7 +536,8 @@ PHP_FUNCTION(posix_ttyname)
+ 		RETURN_FALSE;
+ 	}
+ #endif
+-	RETURN_STRING(p);
++#endif // WASM_WASI
++	RETURN_STRING("");
+ }
+ /* }}} */
+ 
+@@ -628,6 +683,7 @@ int php_posix_group_to_array(struct group *g, zval *array_group) /* {{{ */
+ 	zval array_members;
+ 	int count;
+ 
++#ifndef WASM_WASI
+ 	if (NULL == g)
+ 		return 0;
+ 
+@@ -655,6 +711,9 @@ int php_posix_group_to_array(struct group *g, zval *array_group) /* {{{ */
+ 	zend_hash_str_update(Z_ARRVAL_P(array_group), "members", sizeof("members")-1, &array_members);
+ 	add_assoc_long(array_group, "gid", g->gr_gid);
+ 	return 1;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -712,6 +771,7 @@ PHP_FUNCTION(posix_access)
+ /* {{{ Group database access (POSIX.1, 9.2.1) */
+ PHP_FUNCTION(posix_getgrnam)
+ {
++#ifndef WASM_WASI
+ 	char *name;
+ 	struct group *g;
+ 	size_t name_len;
+@@ -760,12 +820,16 @@ PHP_FUNCTION(posix_getgrnam)
+ #if defined(ZTS) && defined(HAVE_GETGRNAM_R) && defined(_SC_GETGR_R_SIZE_MAX)
+ 	efree(buf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ Group database access (POSIX.1, 9.2.1) */
+ PHP_FUNCTION(posix_getgrgid)
+ {
++#ifndef WASM_WASI
+ 	zend_long gid;
+ #if defined(ZTS) && defined(HAVE_GETGRGID_R) && defined(_SC_GETGR_R_SIZE_MAX)
+ 	int ret;
+@@ -818,11 +882,15 @@ PHP_FUNCTION(posix_getgrgid)
+ #if defined(ZTS) && defined(HAVE_GETGRGID_R) && defined(_SC_GETGR_R_SIZE_MAX)
+ 	efree(grbuf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ int php_posix_passwd_to_array(struct passwd *pw, zval *return_value) /* {{{ */
+ {
++#ifndef WASM_WASI
+ 	if (NULL == pw)
+ 		return 0;
+ 	if (NULL == return_value || Z_TYPE_P(return_value) != IS_ARRAY)
+@@ -836,12 +904,16 @@ int php_posix_passwd_to_array(struct passwd *pw, zval *return_value) /* {{{ */
+ 	add_assoc_string(return_value, "dir",       pw->pw_dir);
+ 	add_assoc_string(return_value, "shell",     pw->pw_shell);
+ 	return 1;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ User database access (POSIX.1, 9.2.2) */
+ PHP_FUNCTION(posix_getpwnam)
+ {
++#ifndef WASM_WASI
+ 	struct passwd *pw;
+ 	char *name;
+ 	size_t name_len;
+@@ -890,12 +962,16 @@ PHP_FUNCTION(posix_getpwnam)
+ #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWNAM_R)
+ 	efree(buf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ User database access (POSIX.1, 9.2.2) */
+ PHP_FUNCTION(posix_getpwuid)
+ {
++#ifndef WASM_WASI
+ 	zend_long uid;
+ #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWUID_R)
+ 	struct passwd _pw;
+@@ -946,6 +1022,9 @@ PHP_FUNCTION(posix_getpwuid)
+ #if defined(ZTS) && defined(_SC_GETPW_R_SIZE_MAX) && defined(HAVE_GETPWUID_R)
+ 	efree(pwbuf);
+ #endif
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/session/mod_files.c b/ext/session/mod_files.c
+index a320756961..aa23f6cb86 100644
+--- a/ext/session/mod_files.c
++++ b/ext/session/mod_files.c
+@@ -189,6 +189,7 @@ static void ps_files_open(ps_files *data, /* const */ zend_string *key)
+ #endif
+ 
+ 		if (data->fd != -1) {
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ 			/* check that this session file was created by us or root – we
+ 			   don't want to end up accepting the sessions of another webapp
+@@ -208,6 +209,7 @@ static void ps_files_open(ps_files *data, /* const */ zend_string *key)
+ 			do {
+ 				ret = flock(data->fd, LOCK_EX);
+ 			} while (ret == -1 && errno == EINTR);
++#endif // WASM_WASI
+ 
+ #ifdef F_SETFD
+ # ifndef FD_CLOEXEC
+diff --git a/ext/standard/basic_functions.c b/ext/standard/basic_functions.c
+index 00713766fd..e3e443b48b 100755
+--- a/ext/standard/basic_functions.c
++++ b/ext/standard/basic_functions.c
+@@ -64,11 +64,13 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
+ #include <sys/stat.h>
+ #endif
+ 
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ # include <netdb.h>
+ #else
+ #include "win32/inet.h"
+ #endif
++#endif // WASM_WASI
+ 
+ #ifdef HAVE_ARPA_INET_H
+ # include <arpa/inet.h>
+@@ -456,9 +458,11 @@ PHP_RSHUTDOWN_FUNCTION(basic) /* {{{ */
+ 	tsrm_env_unlock();
+ #endif
+ 
++#ifndef WASM_WASI
+ 	if (BG(umask) != -1) {
+ 		umask(BG(umask));
+ 	}
++#endif // WASM_WASI
+ 
+ 	/* Check if locale was changed and change it back
+ 	 * to the value in startup environment */
+@@ -2411,6 +2415,7 @@ PHP_FUNCTION(move_uploaded_file)
+ 
+ 	if (VCWD_RENAME(path, new_path) == 0) {
+ 		successful = 1;
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ 		oldmask = umask(077);
+ 		umask(oldmask);
+@@ -2421,6 +2426,7 @@ PHP_FUNCTION(move_uploaded_file)
+ 			php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+ 		}
+ #endif
++#endif // WASM_WASI
+ 	} else if (php_copy_file_ex(path, new_path, STREAM_DISABLE_OPEN_BASEDIR) == SUCCESS) {
+ 		VCWD_UNLINK(path);
+ 		successful = 1;
+diff --git a/ext/standard/dns.c b/ext/standard/dns.c
+index d229b998a4..104f847ab4 100644
+--- a/ext/standard/dns.c
++++ b/ext/standard/dns.c
+@@ -34,7 +34,9 @@
+ #ifdef HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif // WASM_WASI
+ #ifdef _OSD_POSIX
+ #undef STATUS
+ #undef T_UNSPEC
+@@ -172,6 +174,7 @@ PHP_FUNCTION(gethostbyaddr)
+ /* {{{ php_gethostbyaddr */
+ static zend_string *php_gethostbyaddr(char *ip)
+ {
++#ifndef WASM_WASI
+ #if defined(HAVE_IPV6) && defined(HAVE_INET_PTON)
+ 	struct sockaddr_in sa4;
+ 	struct sockaddr_in6 sa6;
+@@ -213,6 +216,9 @@ static zend_string *php_gethostbyaddr(char *ip)
+ 
+ 	return zend_string_init(hp->h_name, strlen(hp->h_name), 0);
+ #endif
++#else
++	return NULL;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -239,6 +245,7 @@ PHP_FUNCTION(gethostbyname)
+ /* {{{ Return a list of IP addresses that a given hostname resolves to. */
+ PHP_FUNCTION(gethostbynamel)
+ {
++#ifndef WASM_WASI
+ 	char *hostname;
+ 	size_t hostname_len;
+ 	struct hostent *hp;
+@@ -280,12 +287,16 @@ PHP_FUNCTION(gethostbynamel)
+ 		add_next_index_string(return_value, inet_ntoa(in));
+ #endif
+ 	}
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+ /* {{{ php_gethostbyname */
+ static zend_string *php_gethostbyname(char *name)
+ {
++#ifndef WASM_WASI
+ 	struct hostent *hp;
+ 	struct in_addr *h_addr_0; /* Don't call this h_addr, it's a macro! */
+ 	struct in_addr in;
+@@ -313,6 +324,9 @@ static zend_string *php_gethostbyname(char *name)
+ 	address = inet_ntoa(in);
+ #endif
+ 	return zend_string_init(address, strlen(address), 0);
++#else
++	return NULL;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/exec.c b/ext/standard/exec.c
+index 1b1b0ab9e9..83d26d93ed 100644
+--- a/ext/standard/exec.c
++++ b/ext/standard/exec.c
+@@ -113,6 +113,7 @@ static size_t handle_line(int type, zval *array, char *buf, size_t bufl) {
+  */
+ PHPAPI int php_exec(int type, const char *cmd, zval *array, zval *return_value)
+ {
++#ifndef WASM_WASI
+ 	FILE *fp;
+ 	char *buf;
+ 	int pclose_return;
+@@ -200,7 +201,10 @@ PHPAPI int php_exec(int type, const char *cmd, zval *array, zval *return_value)
+ 	pclose_return = -1;
+ 	RETVAL_FALSE;
+ 	goto done;
+-}
++#else
++	return 0;
++#endif // WASM_WASI
++ }
+ /* }}} */
+ 
+ static void php_exec_ex(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
+@@ -512,6 +516,7 @@ PHP_FUNCTION(escapeshellarg)
+ /* {{{ Execute command via shell and return complete output as string */
+ PHP_FUNCTION(shell_exec)
+ {
++#ifndef WASM_WASI
+ 	FILE *in;
+ 	char *command;
+ 	size_t command_len;
+@@ -547,7 +552,10 @@ PHP_FUNCTION(shell_exec)
+ 	if (ret && ZSTR_LEN(ret) > 0) {
+ 		RETVAL_STR(ret);
+ 	}
+-}
++#else
++	RETURN_FALSE;
++#endif
++ }
+ /* }}} */
+ 
+ #ifdef HAVE_NICE
+diff --git a/ext/standard/file.c b/ext/standard/file.c
+index 1f3b6b2cf5..03407bbdb3 100644
+--- a/ext/standard/file.c
++++ b/ext/standard/file.c
+@@ -55,7 +55,9 @@
+ # endif
+ # include <sys/socket.h>
+ # include <netinet/in.h>
+-# include <netdb.h>
++# ifndef WASM_WASI
++#  include <netdb.h>
++# endif // WASM_WASI
+ # if HAVE_ARPA_INET_H
+ #  include <arpa/inet.h>
+ # endif
+@@ -793,6 +795,7 @@ PHPAPI PHP_FUNCTION(fclose)
+ /* {{{ Execute a command and open either a read or a write pipe to it */
+ PHP_FUNCTION(popen)
+ {
++#ifndef WASM_WASI
+ 	char *command, *mode;
+ 	size_t command_len, mode_len;
+ 	FILE *fp;
+@@ -842,6 +845,9 @@ PHP_FUNCTION(popen)
+ 	}
+ 
+ 	efree(posix_mode);
++#else
++	RETURN_FALSE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -1223,6 +1229,7 @@ PHP_FUNCTION(readfile)
+ /* {{{ Return or change the umask */
+ PHP_FUNCTION(umask)
+ {
++#ifndef WASM_WASI
+ 	zend_long mask = 0;
+ 	bool mask_is_null = 1;
+ 	int oldumask;
+@@ -1245,6 +1252,9 @@ PHP_FUNCTION(umask)
+ 	}
+ 
+ 	RETURN_LONG(oldumask);
++#else
++	RETURN_LONG(0);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/filestat.c b/ext/standard/filestat.c
+index aaf7e730d0..2fdb9d765c 100644
+--- a/ext/standard/filestat.c
++++ b/ext/standard/filestat.c
+@@ -326,12 +326,16 @@ PHPAPI int php_get_gid_by_name(const char *name, gid_t *gid)
+ 		efree(grbuf);
+ 		*gid = gr.gr_gid;
+ #else
++#ifndef WASM_WASI
+ 		struct group *gr = getgrnam(name);
+ 
+ 		if (!gr) {
+ 			return FAILURE;
+ 		}
+ 		*gid = gr->gr_gid;
++#else
++		*gid = 0;
++#endif // WASM_WASI
+ #endif
+ 		return SUCCESS;
+ }
+@@ -399,6 +403,7 @@ static void php_do_chgrp(INTERNAL_FUNCTION_PARAMETERS, int do_lchgrp) /* {{{ */
+ 		RETURN_FALSE;
+ 	}
+ 
++#ifndef WASM_WASI
+ 	if (do_lchgrp) {
+ #ifdef HAVE_LCHOWN
+ 		ret = VCWD_LCHOWN(filename, -1, gid);
+@@ -410,6 +415,7 @@ static void php_do_chgrp(INTERNAL_FUNCTION_PARAMETERS, int do_lchgrp) /* {{{ */
+ 		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+ 		RETURN_FALSE;
+ 	}
++#endif // WASM_WASI
+ 	RETURN_TRUE;
+ #endif
+ }
+@@ -452,12 +458,16 @@ PHPAPI uid_t php_get_uid_by_name(const char *name, uid_t *uid)
+ 		efree(pwbuf);
+ 		*uid = pw.pw_uid;
+ #else
++#ifndef WASM_WASI
+ 		struct passwd *pw = getpwnam(name);
+ 
+ 		if (!pw) {
+ 			return FAILURE;
+ 		}
+ 		*uid = pw->pw_uid;
++#else
++		*uid = 0;
++#endif // WASM_WASI
+ #endif
+ 		return SUCCESS;
+ }
+@@ -465,6 +475,7 @@ PHPAPI uid_t php_get_uid_by_name(const char *name, uid_t *uid)
+ 
+ static void php_do_chown(INTERNAL_FUNCTION_PARAMETERS, int do_lchown) /* {{{ */
+ {
++#ifndef WASM_WASI
+ 	char *filename;
+ 	size_t filename_len;
+ 	zend_string *user_str;
+@@ -539,6 +550,9 @@ static void php_do_chown(INTERNAL_FUNCTION_PARAMETERS, int do_lchown) /* {{{ */
+ 	}
+ 	RETURN_TRUE;
+ #endif
++#else
++	RETURN_TRUE;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -563,6 +577,7 @@ PHP_FUNCTION(lchown)
+ /* {{{ Change file mode */
+ PHP_FUNCTION(chmod)
+ {
++#ifndef WASM_WASI
+ 	char *filename;
+ 	size_t filename_len;
+ 	zend_long mode;
+@@ -601,6 +616,7 @@ PHP_FUNCTION(chmod)
+ 		php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+ 		RETURN_FALSE;
+ 	}
++#endif // WASM_WASI
+ 	RETURN_TRUE;
+ }
+ /* }}} */
+@@ -855,6 +871,7 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
+ 
+ 	stat_sb = &ssb.sb;
+ 
++#ifndef WASM_WASI
+ 	if (type >= FS_IS_W && type <= FS_IS_X) {
+ 		if(ssb.sb.st_uid==getuid()) {
+ 			rmask=S_IRUSR;
+@@ -895,6 +912,7 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
+ 			}
+ 		}
+ 	}
++#endif // WASM_WASI
+ 
+ 	switch (type) {
+ 	case FS_PERMS:
+@@ -919,7 +937,9 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
+ 			RETURN_STRING("link");
+ 		}
+ 		switch(ssb.sb.st_mode & S_IFMT) {
++#ifndef WASM_WASI
+ 		case S_IFIFO: RETURN_STRING("fifo");
++#endif // WASM_WASI
+ 		case S_IFCHR: RETURN_STRING("char");
+ 		case S_IFDIR: RETURN_STRING("dir");
+ 		case S_IFBLK: RETURN_STRING("block");
+diff --git a/ext/standard/flock_compat.c b/ext/standard/flock_compat.c
+index 8622ec1aec..7aae46c392 100644
+--- a/ext/standard/flock_compat.c
++++ b/ext/standard/flock_compat.c
+@@ -26,7 +26,12 @@ PHPAPI int flock(int fd, int operation)
+ #endif /* !defined(HAVE_FLOCK) */
+ 
+ PHPAPI int php_flock(int fd, int operation)
+-#ifdef HAVE_STRUCT_FLOCK /* {{{ */
++#if defined(WASM_WASI)
++{
++	errno = 0;
++	return 0;
++}
++#elif defined(HAVE_STRUCT_FLOCK) /* {{{ */
+ {
+ 	struct flock flck;
+ 	int ret;
+diff --git a/ext/standard/ftp_fopen_wrapper.c b/ext/standard/ftp_fopen_wrapper.c
+index 0be729a59f..31180f329c 100644
+--- a/ext/standard/ftp_fopen_wrapper.c
++++ b/ext/standard/ftp_fopen_wrapper.c
+@@ -48,8 +48,10 @@
+ #include <winsock2.h>
+ #else
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
+-#ifdef HAVE_ARPA_INET_H
++#endif // WASM_WASI
++#if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+ #endif
+diff --git a/ext/standard/http_fopen_wrapper.c b/ext/standard/http_fopen_wrapper.c
+index be0ee30b7d..2432220bcc 100644
+--- a/ext/standard/http_fopen_wrapper.c
++++ b/ext/standard/http_fopen_wrapper.c
+@@ -51,8 +51,10 @@
+ #include <winsock2.h>
+ #else
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
+-#ifdef HAVE_ARPA_INET_H
++#endif // WASM_WASI
++#if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+ #endif
+diff --git a/ext/standard/mail.c b/ext/standard/mail.c
+index 55790e6100..90fad42650 100644
+--- a/ext/standard/mail.c
++++ b/ext/standard/mail.c
+@@ -372,6 +372,7 @@ static int php_mail_detect_multiple_crlf(const char *hdr) {
+ /* {{{ php_mail */
+ PHPAPI int php_mail(const char *to, const char *subject, const char *message, const char *headers, const char *extra_cmd)
+ {
++#ifndef WASM_WASI
+ #ifdef PHP_WIN32
+ 	int tsm_err;
+ 	char *tsm_errmsg = NULL;
+@@ -551,6 +552,9 @@ PHPAPI int php_mail(const char *to, const char *subject, const char *message, co
+ 	}
+ 
+ 	MAIL_RET(1); /* never reached */
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/microtime.c b/ext/standard/microtime.c
+index ca8643eb51..f39e90fdc0 100644
+--- a/ext/standard/microtime.c
++++ b/ext/standard/microtime.c
+@@ -126,6 +126,7 @@ PHP_FUNCTION(getrusage)
+ 	PHP_RUSAGE_PARA(ru_majflt);
+ 	PHP_RUSAGE_PARA(ru_maxrss);
+ #elif !defined(_OSD_POSIX) && !defined(__HAIKU__)
++#ifndef WASM_WASI
+ 	PHP_RUSAGE_PARA(ru_oublock);
+ 	PHP_RUSAGE_PARA(ru_inblock);
+ 	PHP_RUSAGE_PARA(ru_msgsnd);
+@@ -139,6 +140,7 @@ PHP_FUNCTION(getrusage)
+ 	PHP_RUSAGE_PARA(ru_nvcsw);
+ 	PHP_RUSAGE_PARA(ru_nivcsw);
+ 	PHP_RUSAGE_PARA(ru_nswap);
++#endif // WASM_WASI
+ #endif /*_OSD_POSIX*/
+ 	PHP_RUSAGE_PARA(ru_utime.tv_usec);
+ 	PHP_RUSAGE_PARA(ru_utime.tv_sec);
+diff --git a/ext/standard/net.c b/ext/standard/net.c
+index b22f304c8e..e385b5de6b 100644
+--- a/ext/standard/net.c
++++ b/ext/standard/net.c
+@@ -43,7 +43,7 @@
+ # include <ws2ipdef.h>
+ # include <Ws2tcpip.h>
+ # include <iphlpapi.h>
+-#else
++#elif ! defined(WASM_WASI)
+ # include <netdb.h>
+ #endif
+ 
+@@ -86,6 +86,7 @@ PHPAPI zend_string* php_inet_ntop(const struct sockaddr *addr) {
+ 			ZEND_FALLTHROUGH;
+ #endif
+ 		case AF_INET: {
++#ifndef WASM_WASI
+ 			zend_string *ret = zend_string_alloc(NI_MAXHOST, 0);
+ 			if (getnameinfo(addr, addrlen, ZSTR_VAL(ret), NI_MAXHOST, NULL, 0, NI_NUMERICHOST) == SUCCESS) {
+ 				/* Also demangle numeric host with %name suffix */
+@@ -96,6 +97,9 @@ PHPAPI zend_string* php_inet_ntop(const struct sockaddr *addr) {
+ 			}
+ 			zend_string_efree(ret);
+ 			break;
++#else
++			return NULL;
++#endif // WASM_WASI
+ 		}
+ 	}
+ 
+diff --git a/ext/standard/pageinfo.c b/ext/standard/pageinfo.c
+index f24659a95e..472f7e4a56 100644
+--- a/ext/standard/pageinfo.c
++++ b/ext/standard/pageinfo.c
+@@ -61,8 +61,10 @@ PHPAPI void php_statpage(void)
+ 			BG(page_inode) = pstat->st_ino;
+ 			BG(page_mtime) = pstat->st_mtime;
+ 		} else { /* handler for situations where there is no source file, ex. php -r */
++#ifndef WASM_WASI
+ 			BG(page_uid) = getuid();
+ 			BG(page_gid) = getgid();
++#endif // WASM_WASI
+ 		}
+ 	}
+ }
+@@ -71,20 +73,29 @@ PHPAPI void php_statpage(void)
+ /* {{{ php_getuid */
+ zend_long php_getuid(void)
+ {
++#ifndef WASM_WASI
+ 	php_statpage();
+ 	return (BG(page_uid));
++#else
++	return 0;
++#endif //WASM_WASI
+ }
+ /* }}} */
+ 
+ zend_long php_getgid(void)
+ {
++#ifndef WASM_WASI
+ 	php_statpage();
+ 	return (BG(page_gid));
++#else
++	return 0;
++#endif //WASM_WASI
+ }
+ 
+ /* {{{ Get PHP script owner's UID */
+ PHP_FUNCTION(getmyuid)
+ {
++#ifndef WASM_WASI
+ 	zend_long uid;
+ 
+ 	ZEND_PARSE_PARAMETERS_NONE();
+@@ -95,6 +106,9 @@ PHP_FUNCTION(getmyuid)
+ 	} else {
+ 		RETURN_LONG(uid);
+ 	}
++#else
++	RETURN_LONG(0);
++#endif //WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/php_fopen_wrapper.c b/ext/standard/php_fopen_wrapper.c
+index 8926485025..be3fc6fd7b 100644
+--- a/ext/standard/php_fopen_wrapper.c
++++ b/ext/standard/php_fopen_wrapper.c
+@@ -246,13 +246,17 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			static int cli_in = 0;
+ 			fd = STDIN_FILENO;
+ 			if (cli_in) {
+-				fd = dup(fd);
++#ifndef WASM_WASI
++ 				fd = dup(fd);
++#endif // WASM_WASI
+ 			} else {
+ 				cli_in = 1;
+ 				file = stdin;
+ 			}
+ 		} else {
++#ifndef WASM_WASI
+ 			fd = dup(STDIN_FILENO);
++#endif // WASM_WASI
+ 		}
+ #ifdef PHP_WIN32
+ 		pipe_requested = 1;
+@@ -262,13 +266,17 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			static int cli_out = 0;
+ 			fd = STDOUT_FILENO;
+ 			if (cli_out++) {
+-				fd = dup(fd);
++#ifndef WASM_WASI
++ 				fd = dup(fd);
++#endif // WASM_WASI
+ 			} else {
+ 				cli_out = 1;
+ 				file = stdout;
+ 			}
+ 		} else {
++#ifndef WASM_WASI
+ 			fd = dup(STDOUT_FILENO);
++#endif // WASM_WASI
+ 		}
+ #ifdef PHP_WIN32
+ 		pipe_requested = 1;
+@@ -278,13 +286,17 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			static int cli_err = 0;
+ 			fd = STDERR_FILENO;
+ 			if (cli_err++) {
++#ifndef WASM_WASI
+ 				fd = dup(fd);
++#endif // WASM_WASI
+ 			} else {
+ 				cli_err = 1;
+ 				file = stderr;
+ 			}
+ 		} else {
++#ifndef WASM_WASI
+ 			fd = dup(STDERR_FILENO);
++#endif // WASM_WASI
+ 		}
+ #ifdef PHP_WIN32
+ 		pipe_requested = 1;
+@@ -317,7 +329,7 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			return NULL;
+ 		}
+ 
+-#ifdef HAVE_UNISTD_H
++#if defined(HAVE_UNISTD_H) && !defined(WASM_WASI)
+ 		dtablesize = getdtablesize();
+ #else
+ 		dtablesize = INT_MAX;
+@@ -329,6 +341,7 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 			return NULL;
+ 		}
+ 
++#ifndef WASM_WASI
+ 		fd = dup((int)fildes_ori);
+ 		if (fd == -1) {
+ 			php_stream_wrapper_log_error(wrapper, options,
+@@ -336,6 +349,7 @@ php_stream * php_stream_url_wrap_php(php_stream_wrapper *wrapper, const char *pa
+ 				"[%d]: %s", fildes_ori, errno, strerror(errno));
+ 			return NULL;
+ 		}
++#endif // WASM_WASI
+ 	} else if (!strncasecmp(path, "filter/", 7)) {
+ 		/* Save time/memory when chain isn't specified */
+ 		if (strchr(mode, 'r') || strchr(mode, '+')) {
+diff --git a/main/fastcgi.c b/main/fastcgi.c
+index a77491f1bf..ec29595e70 100644
+--- a/main/fastcgi.c
++++ b/main/fastcgi.c
+@@ -69,7 +69,9 @@ static int is_impersonate = 0;
+ # include <netinet/in.h>
+ # include <netinet/tcp.h>
+ # include <arpa/inet.h>
++# ifndef WASM_WASI
+ # include <netdb.h>
++# endif // WASM_WASI
+ # include <signal.h>
+ 
+ # if defined(HAVE_POLL_H) && defined(HAVE_POLL)
+@@ -431,6 +433,7 @@ static void fcgi_signal_handler(int signo)
+ 
+ static void fcgi_setup_signals(void)
+ {
++#ifndef WASM_WASI
+ 	struct sigaction new_sa, old_sa;
+ 
+ 	sigemptyset(&new_sa.sa_mask);
+@@ -442,6 +445,7 @@ static void fcgi_setup_signals(void)
+ 	if (old_sa.sa_handler == SIG_DFL) {
+ 		sigaction(SIGPIPE, &new_sa, NULL);
+ 	}
++#endif // WASM_WASI
+ }
+ #endif
+ 
+@@ -526,6 +530,8 @@ int fcgi_init(void)
+ 		} else {
+ 			return is_fastcgi = 0;
+ 		}
++#elif defined(WASM_WASI)
++		return is_fastcgi = 0;
+ #else
+ 		errno = 0;
+ 		if (getpeername(0, (struct sockaddr *)&sa, &len) != 0 && errno == ENOTCONN) {
+@@ -675,6 +681,7 @@ int fcgi_listen(const char *path, int backlog)
+ 
+ 	/* Prepare socket address */
+ 	if (tcp) {
++#ifndef WASM_WASI
+ 		memset(&sa.sa_inet, 0, sizeof(sa.sa_inet));
+ 		sa.sa_inet.sin_family = AF_INET;
+ 		sa.sa_inet.sin_port = htons(port);
+@@ -767,6 +774,7 @@ int fcgi_listen(const char *path, int backlog)
+ 	if (!tcp) {
+ 		chmod(path, 0777);
+ 	} else {
++#endif // WASM_WASI
+ 		char *ip = getenv("FCGI_WEB_SERVER_ADDRS");
+ 		char *cur, *end;
+ 		int n;
+@@ -1099,7 +1107,9 @@ static int fcgi_read_request(fcgi_request *req)
+ 			int on = 1;
+ # endif
+ 
++# ifndef WASM_WASI
+ 			setsockopt(req->fd, IPPROTO_TCP, TCP_NODELAY, (char*)&on, sizeof(on));
++# endif // WASM_WASI
+ 			req->nodelay = 1;
+ 		}
+ #endif
+@@ -1409,7 +1419,9 @@ int fcgi_accept_request(fcgi_request *req)
+ 					client_sa = sa;
+ 					if (req->fd >= 0 && !fcgi_is_allowed()) {
+ 						fcgi_log(FCGI_ERROR, "Connection disallowed: IP address '%s' has been dropped.", fcgi_get_last_client_ip());
++#ifndef WASM_WASI
+ 						closesocket(req->fd);
++#endif // WASM_WASI
+ 						req->fd = -1;
+ 						continue;
+ 					}
+diff --git a/main/fopen_wrappers.c b/main/fopen_wrappers.c
+index f6ce26e104..3d7c67b2de 100644
+--- a/main/fopen_wrappers.c
++++ b/main/fopen_wrappers.c
+@@ -52,7 +52,9 @@
+ #include <winsock2.h>
+ #else
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif // WASM_WASI
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+diff --git a/main/main.c b/main/main.c
+index 8be52d316a..8417a40ae5 100644
+--- a/main/main.c
++++ b/main/main.c
+@@ -1409,6 +1409,7 @@ static ZEND_COLD void php_error_cb(int orig_type, zend_string *error_filename, c
+ /* {{{ php_get_current_user */
+ PHPAPI char *php_get_current_user(void)
+ {
++#ifndef WASM_WASI
+ 	zend_stat_t *pstat = NULL;
+ 
+ 	if (SG(request_info).current_user) {
+@@ -1471,6 +1472,9 @@ PHPAPI char *php_get_current_user(void)
+ 		return SG(request_info).current_user;
+ #endif
+ 	}
++#else
++	return "";
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+diff --git a/main/network.c b/main/network.c
+index a189714aaf..6fb97865cb 100644
+--- a/main/network.c
++++ b/main/network.c
+@@ -54,7 +54,9 @@
+ 
+ #ifndef PHP_WIN32
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif // WASM_WASI
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+@@ -153,6 +155,7 @@ PHPAPI void php_network_freeaddresses(struct sockaddr **sal)
+  */
+ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct sockaddr ***sal, zend_string **error_string)
+ {
++#ifndef WASM_WASI
+ 	struct sockaddr **sap;
+ 	int n;
+ #if HAVE_GETADDRINFO
+@@ -275,6 +278,9 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
+ 
+ 	*sap = NULL;
+ 	return n;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -310,6 +316,7 @@ PHPAPI int php_network_connect_socket(php_socket_t sockfd,
+ 		zend_string **error_string,
+ 		int *error_code)
+ {
++#ifndef WASM_WASI
+ 	php_non_blocking_flags_t orig_flags;
+ 	int n;
+ 	int error = 0;
+@@ -403,6 +410,9 @@ static inline void sub_times(struct timeval a, struct timeval b, struct timeval
+ 		result->tv_sec++;
+ 		result->tv_usec -= 1000000L;
+ 	}
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -447,7 +457,11 @@ php_socket_t php_network_bind_socket_to_local_addr(const char *host, unsigned po
+ 		}
+ 
+ 		/* create a socket for this address */
++#ifndef WASM_WASI
+ 		sock = socket(sa->sa_family, socktype, 0);
++#else
++		sock = SOCK_ERR;
++#endif // WASM_WASI
+ 
+ 		if (sock == SOCK_ERR) {
+ 			continue;
+@@ -456,31 +470,45 @@ php_socket_t php_network_bind_socket_to_local_addr(const char *host, unsigned po
+ 		/* attempt to bind */
+ 
+ #ifdef SO_REUSEADDR
++#ifndef WASM_WASI
+ 		setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI
+ #endif
+ #ifdef IPV6_V6ONLY
+ 		if (sockopts & STREAM_SOCKOP_IPV6_V6ONLY) {
+ 			int ipv6_val = !!(sockopts & STREAM_SOCKOP_IPV6_V6ONLY_ENABLED);
++#ifndef WASM_WASI
+ 			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&ipv6_val, sizeof(sockoptval));
++#endif // WASM_WASI
+ 		}
+ #endif
+ #ifdef SO_REUSEPORT
+ 		if (sockopts & STREAM_SOCKOP_SO_REUSEPORT) {
++#ifndef WASM_WASI
+ 			setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI
+ 		}
+ #endif
+ #ifdef SO_BROADCAST
+ 		if (sockopts & STREAM_SOCKOP_SO_BROADCAST) {
++#ifndef WASM_WASI
+ 			setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI
+ 		}
+ #endif
+ #ifdef TCP_NODELAY
+ 		if (sockopts & STREAM_SOCKOP_TCP_NODELAY) {
++#ifndef WASM_WASI
+ 			setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char*)&sockoptval, sizeof(sockoptval));
++#endif // WASM_WASI
+ 		}
+ #endif
+ 
++#ifndef WASM_WASI
+ 		n = bind(sock, sa, socklen);
++#else
++		n = SOCK_CONN_ERR;
++#endif // WASM_WASI
+ 
+ 		if (n != SOCK_CONN_ERR) {
+ 			goto bound;
+@@ -613,6 +641,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
+ 		socklen_t *addrlen
+ 		)
+ {
++#ifndef WASM_WASI
+ 	if (addr) {
+ 		*addr = emalloc(sl);
+ 		memcpy(*addr, sa, sl);
+@@ -670,6 +699,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
+ 		}
+ 
+ 	}
++#endif // WASM_WASI
+ }
+ 
+ PHPAPI int php_network_get_peer_name(php_socket_t sock,
+@@ -678,6 +708,7 @@ PHPAPI int php_network_get_peer_name(php_socket_t sock,
+ 		socklen_t *addrlen
+ 		)
+ {
++#ifndef WASM_WASI
+ 	php_sockaddr_storage sa;
+ 	socklen_t sl = sizeof(sa);
+ 	memset(&sa, 0, sizeof(sa));
+@@ -690,6 +721,9 @@ PHPAPI int php_network_get_peer_name(php_socket_t sock,
+ 		return 0;
+ 	}
+ 	return -1;
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ 
+ PHPAPI int php_network_get_sock_name(php_socket_t sock,
+@@ -698,6 +732,7 @@ PHPAPI int php_network_get_sock_name(php_socket_t sock,
+ 		socklen_t *addrlen
+ 		)
+ {
++#ifndef WASM_WASI
+ 	php_sockaddr_storage sa;
+ 	socklen_t sl = sizeof(sa);
+ 	memset(&sa, 0, sizeof(sa));
+@@ -710,7 +745,9 @@ PHPAPI int php_network_get_sock_name(php_socket_t sock,
+ 		return 0;
+ 	}
+ 	return -1;
+-
++#else
++	return 0;
++#endif // WASM_WASI
+ }
+ 
+ 
+@@ -756,7 +793,9 @@ PHPAPI php_socket_t php_network_accept_incoming(php_socket_t srvsock,
+ 					);
+ 			if (tcp_nodelay) {
+ #ifdef TCP_NODELAY
++#ifndef WASM_WASI
+ 				setsockopt(clisock, IPPROTO_TCP, TCP_NODELAY, (char*)&tcp_nodelay, sizeof(tcp_nodelay));
++#endif // WASM_WASI
+ #endif
+ 			}
+ 		} else {
+@@ -873,7 +912,9 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
+ 					local_address_len = sizeof(struct sockaddr_in);
+ 					local_address.in4.sin_family = sa->sa_family;
+ 					local_address.in4.sin_port = htons(bindport);
++#ifndef WASM_WASI
+ 					memset(&(local_address.in4.sin_zero), 0, sizeof(local_address.in4.sin_zero));
++#endif // WASM_WASI
+ 				}
+ 			}
+ #if HAVE_IPV6 && HAVE_INET_PTON
+@@ -907,7 +948,9 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
+ 		{
+ 			int val = 1;
+ 			if (sockopts & STREAM_SOCKOP_SO_BROADCAST) {
++#ifndef WASM_WASI
+ 				setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char*)&val, sizeof(val));
++#endif // WASM_WASI
+ 			}
+ 		}
+ #endif
+@@ -916,7 +959,9 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
+ 		{
+ 			int val = 1;
+ 			if (sockopts & STREAM_SOCKOP_TCP_NODELAY) {
++#ifndef WASM_WASI
+ 				setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char*)&val, sizeof(val));
++#endif // WASM_WASI
+ 			}
+ 		}
+ #endif
+@@ -1329,6 +1374,7 @@ struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char *
+ #endif
+ 
+ PHPAPI struct hostent*	php_network_gethostbyname(const char *name) {
++#ifndef WASM_WASI
+ #if !defined(HAVE_GETHOSTBYNAME_R)
+ 	return gethostbyname(name);
+ #else
+@@ -1343,4 +1389,7 @@ PHPAPI struct hostent*	php_network_gethostbyname(const char *name) {
+ 
+ 	return gethostname_re(name, &FG(tmp_host_info), &FG(tmp_host_buf), &FG(tmp_host_buf_len));
+ #endif
++#else
++	return NULL;
++#endif // WASM_WASI
+ }
+diff --git a/main/php_open_temporary_file.c b/main/php_open_temporary_file.c
+index dcea783584..57bd337835 100644
+--- a/main/php_open_temporary_file.c
++++ b/main/php_open_temporary_file.c
+@@ -30,7 +30,9 @@
+ #include <sys/param.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
++#ifndef WASM_WASI
+ #include <netdb.h>
++#endif
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+@@ -97,7 +99,7 @@ static int php_do_open_temporary_file(const char *path, const char *pfx, zend_st
+ 	char cwd[MAXPATHLEN];
+ 	cwd_state new_state;
+ 	int fd = -1;
+-#ifndef HAVE_MKSTEMP
++#if !defined(HAVE_MKSTEMP) || defined(WASM_WASI)
+ 	int open_flags = O_CREAT | O_TRUNC | O_RDWR
+ #ifdef PHP_WIN32
+ 		| _O_BINARY
+@@ -177,6 +179,8 @@ static int php_do_open_temporary_file(const char *path, const char *pfx, zend_st
+ 	free(pfxw);
+ #elif defined(HAVE_MKSTEMP)
+ 	fd = mkstemp(opened_path);
++#elif defined(WASM_WASI)
++	fd = VCWD_OPEN(opened_path, open_flags);
+ #else
+ 	if (mktemp(opened_path)) {
+ 		fd = VCWD_OPEN(opened_path, open_flags);
+diff --git a/main/php_syslog.c b/main/php_syslog.c
+index fa71a86313..68c7aac707 100644
+--- a/main/php_syslog.c
++++ b/main/php_syslog.c
+@@ -105,6 +105,7 @@ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
+ #else
+ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
+ {
++#ifndef WASM_WASI
+ 	zend_string *fbuf = NULL;
+ 	va_list args;
+ 
+@@ -124,6 +125,7 @@ PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
+ 	php_syslog_str(priority, fbuf);
+ 
+ 	zend_string_release(fbuf);
++#endif // WASM_WASI
+ }
+ /* }}} */
+ #endif
+diff --git a/main/streams/plain_wrapper.c b/main/streams/plain_wrapper.c
+index e9a30f3334..f72825e153 100644
+--- a/main/streams/plain_wrapper.c
++++ b/main/streams/plain_wrapper.c
+@@ -493,7 +493,9 @@ static int php_stdiop_close(php_stream *stream, int close_handle)
+ 		if (data->file) {
+ 			if (data->is_process_pipe) {
+ 				errno = 0;
++#ifndef WASM_WASI
+ 				ret = pclose(data->file);
++#endif
+ 
+ #ifdef HAVE_SYS_WAIT_H
+ 				if (WIFEXITED(ret)) {
+@@ -1304,13 +1306,18 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
+ 			zend_stat_t sb;
+ # if !defined(ZTS) && !defined(TSRM_WIN32)
+ 			/* not sure what to do in ZTS case, umask is not thread-safe */
++# ifndef WASM_WASI
+ 			int oldmask = umask(077);
++# else
++			int oldmask = 077;
++# endif // WASM_WASI
+ # endif
+ 			int success = 0;
+ 			if (php_copy_file(url_from, url_to) == SUCCESS) {
+ 				if (VCWD_STAT(url_from, &sb) == 0) {
+ 					success = 1;
+-#  ifndef TSRM_WIN32
++#  ifndef WASM_WASI
++#   ifndef TSRM_WIN32
+ 					/*
+ 					 * Try to set user and permission info on the target.
+ 					 * If we're not root, then some of these may fail.
+@@ -1333,7 +1340,8 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
+ 							}
+ 						}
+ 					}
+-#  endif
++#   endif
++#  endif // WASM_WASI
+ 					if (success) {
+ 						VCWD_UNLINK(url_from);
+ 					}
+@@ -1344,7 +1352,9 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
+ 				php_error_docref2(NULL, url_from, url_to, E_WARNING, "%s", strerror(errno));
+ 			}
+ #  if !defined(ZTS) && !defined(TSRM_WIN32)
++#  ifndef WASM_WASI
+ 			umask(oldmask);
++#  endif // WASM_WASI
+ #  endif
+ 			return success;
+ 		}
+@@ -1535,7 +1545,11 @@ static int php_plain_files_metadata(php_stream_wrapper *wrapper, const char *url
+ 			} else {
+ 				uid = (uid_t)*(long *)value;
+ 			}
++#ifndef WASM_WASI
+ 			ret = VCWD_CHOWN(url, uid, -1);
++#else
++			ret = 0;
++#endif // WASM_WASI
+ 			break;
+ 		case PHP_STREAM_META_GROUP:
+ 		case PHP_STREAM_META_GROUP_NAME:
+@@ -1547,12 +1561,20 @@ static int php_plain_files_metadata(php_stream_wrapper *wrapper, const char *url
+ 			} else {
+ 				gid = (gid_t)*(long *)value;
+ 			}
+-			ret = VCWD_CHOWN(url, -1, gid);
++#ifndef WASM_WASI
++			ret = VCWD_CHvOWN(url, -1, gid);
++#else
++			ret = 0;
++#endif // WASM_WASI
+ 			break;
+ #endif
+ 		case PHP_STREAM_META_ACCESS:
+ 			mode = (mode_t)*(zend_long *)value;
++#ifndef WASM_WASI
+ 			ret = VCWD_CHMOD(url, mode);
++#else
++			ret = 0;
++#endif // WASM_WASI
+ 			break;
+ 		default:
+ 			zend_value_error("Unknown option %d for stream_metadata", option);
+diff --git a/main/streams/xp_socket.c b/main/streams/xp_socket.c
+index be41d3dde7..b9d9f077cb 100644
+--- a/main/streams/xp_socket.c
++++ b/main/streams/xp_socket.c
+@@ -219,7 +219,9 @@ static int php_sockop_close(php_stream *stream, int close_handle)
+ 				n = php_pollfd_for_ms(sock->socket, POLLOUT, 500);
+ 			} while (n == -1 && php_socket_errno() == EINTR);
+ #endif
++#ifndef WASM_WASI
+ 			closesocket(sock->socket);
++#endif // WASM_WASI
+ 			sock->socket = SOCK_ERR;
+ 		}
+ 
+@@ -256,8 +258,11 @@ static inline int sock_sendto(php_netstream_data_t *sock, const char *buf, size_
+ {
+ 	int ret;
+ 	if (addr) {
++#ifndef WASM_WASI
+ 		ret = sendto(sock->socket, buf, XP_SOCK_BUF_SIZE(buflen), flags, addr, XP_SOCK_BUF_SIZE(addrlen));
+-
++#else
++		ret = 0;
++#endif // WASM_WASI
+ 		return (ret == SOCK_CONN_ERR) ? -1 : ret;
+ 	}
+ #ifdef PHP_WIN32
+@@ -278,7 +283,11 @@ static inline int sock_recvfrom(php_netstream_data_t *sock, char *buf, size_t bu
+ 	if (want_addr) {
+ 		php_sockaddr_storage sa;
+ 		socklen_t sl = sizeof(sa);
++#ifndef WASM_WASI
+ 		ret = recvfrom(sock->socket, buf, XP_SOCK_BUF_SIZE(buflen), flags, (struct sockaddr*)&sa, &sl);
++#else
++		ret = 0;
++#endif // WASM_WASI
+ 		ret = (ret == SOCK_CONN_ERR) ? -1 : ret;
+ #ifdef PHP_WIN32
+ 		/* POSIX discards excess bytes without signalling failure; emulate this on Windows */
+@@ -337,6 +346,7 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 
+ 				if (sock->socket == -1) {
+ 					alive = 0;
++#ifndef WASM_WASI
+ 				} else if ((value == 0 && ((MSG_DONTWAIT != 0) || !sock->is_blocked)) || php_pollfd_for(sock->socket, PHP_POLLREADABLE|POLLPRI, &tv) > 0) {
+ 					/* the poll() call was skipped if the socket is non-blocking (or MSG_DONTWAIT is available) and if the timeout is zero */
+ #ifdef PHP_WIN32
+@@ -352,6 +362,7 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 						(0 > ret && err != EWOULDBLOCK && err != EAGAIN && err != EMSGSIZE)) { /* there was an unrecoverable error */
+ 						alive = 0;
+ 					}
++#endif // WASM_WASI
+ 				}
+ 				return alive ? PHP_STREAM_OPTION_RETURN_OK : PHP_STREAM_OPTION_RETURN_ERR;
+ 			}
+@@ -380,7 +391,11 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 
+ 			switch (xparam->op) {
+ 				case STREAM_XPORT_OP_LISTEN:
++#ifndef WASM_WASI
+ 					xparam->outputs.returncode = (listen(sock->socket, xparam->inputs.backlog) == 0) ?  0: -1;
++#else
++					xparam->outputs.returncode = 0;
++#endif // WASM_WASI
+ 					return PHP_STREAM_OPTION_RETURN_OK;
+ 
+ 				case STREAM_XPORT_OP_GET_NAME:
+@@ -402,7 +417,9 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 				case STREAM_XPORT_OP_SEND:
+ 					flags = 0;
+ 					if ((xparam->inputs.flags & STREAM_OOB) == STREAM_OOB) {
++#ifndef WASM_WASI
+ 						flags |= MSG_OOB;
++#endif // WASM_WASI
+ 					}
+ 					xparam->outputs.returncode = sock_sendto(sock,
+ 							xparam->inputs.buf, xparam->inputs.buflen,
+@@ -420,10 +437,14 @@ static int php_sockop_set_option(php_stream *stream, int option, int value, void
+ 				case STREAM_XPORT_OP_RECV:
+ 					flags = 0;
+ 					if ((xparam->inputs.flags & STREAM_OOB) == STREAM_OOB) {
++#ifndef WASM_WASI
+ 						flags |= MSG_OOB;
++#endif // WASM_WASI
+ 					}
+ 					if ((xparam->inputs.flags & STREAM_PEEK) == STREAM_PEEK) {
++#ifndef WASM_WASI
+ 						flags |= MSG_PEEK;
++#endif // WASM_WASI
+ 					}
+ 					xparam->outputs.returncode = sock_recvfrom(sock,
+ 							xparam->inputs.buf, xparam->inputs.buflen,
+@@ -557,6 +578,7 @@ static inline int parse_unix_address(php_stream_xport_param *xparam, struct sock
+ 	memset(unix_addr, 0, sizeof(*unix_addr));
+ 	unix_addr->sun_family = AF_UNIX;
+ 
++#ifndef WASM_WASI
+ 	/* we need to be binary safe on systems that support an abstract
+ 	 * namespace */
+ 	if (xparam->inputs.namelen >= sizeof(unix_addr->sun_path)) {
+@@ -572,6 +594,7 @@ static inline int parse_unix_address(php_stream_xport_param *xparam, struct sock
+ 	}
+ 
+ 	memcpy(unix_addr->sun_path, xparam->inputs.name, xparam->inputs.namelen);
++#endif // WASM_WASI
+ 
+ 	return 1;
+ }
+@@ -633,7 +656,9 @@ static inline int php_tcp_sockop_bind(php_stream *stream, php_netstream_data_t *
+ 	if (stream->ops == &php_stream_unix_socket_ops || stream->ops == &php_stream_unixdg_socket_ops) {
+ 		struct sockaddr_un unix_addr;
+ 
++#ifndef WASM_WASI
+ 		sock->socket = socket(PF_UNIX, stream->ops == &php_stream_unix_socket_ops ? SOCK_STREAM : SOCK_DGRAM, 0);
++#endif // WASM_WASI
+ 
+ 		if (sock->socket == SOCK_ERR) {
+ 			if (xparam->want_errortext) {
+@@ -646,8 +671,12 @@ static inline int php_tcp_sockop_bind(php_stream *stream, php_netstream_data_t *
+ 
+ 		parse_unix_address(xparam, &unix_addr);
+ 
++#ifndef WASM_WASI
+ 		return bind(sock->socket, (const struct sockaddr *)&unix_addr,
+ 			(socklen_t) XtOffsetOf(struct sockaddr_un, sun_path) + xparam->inputs.namelen);
++#else
++		return 0;
++#endif // WASM_WASI
+ 	}
+ #endif
+ 
+@@ -714,7 +743,9 @@ static inline int php_tcp_sockop_connect(php_stream *stream, php_netstream_data_
+ 	if (stream->ops == &php_stream_unix_socket_ops || stream->ops == &php_stream_unixdg_socket_ops) {
+ 		struct sockaddr_un unix_addr;
+ 
++#ifndef WASM_WASI
+ 		sock->socket = socket(PF_UNIX, stream->ops == &php_stream_unix_socket_ops ? SOCK_STREAM : SOCK_DGRAM, 0);
++#endif // WASM_WASI
+ 
+ 		if (sock->socket == SOCK_ERR) {
+ 			if (xparam->want_errortext) {
+@@ -726,7 +757,11 @@ static inline int php_tcp_sockop_connect(php_stream *stream, php_netstream_data_
+ 		parse_unix_address(xparam, &unix_addr);
+ 
+ 		ret = php_network_connect_socket(sock->socket,
++#ifndef WASM_WASI
+ 				(const struct sockaddr *)&unix_addr, (socklen_t) XtOffsetOf(struct sockaddr_un, sun_path) + xparam->inputs.namelen,
++#else
++				(const struct sockaddr *)&unix_addr, xparam->inputs.namelen,
++#endif // WASM_WASI
+ 				xparam->op == STREAM_XPORT_OP_CONNECT_ASYNC, xparam->inputs.timeout,
+ 				xparam->want_errortext ? &xparam->outputs.error_text : NULL,
+ 				&err);
+diff --git a/sapi/cgi/cgi_main.c b/sapi/cgi/cgi_main.c
+index b45468031f..7d5ddf0880 100644
+--- a/sapi/cgi/cgi_main.c
++++ b/sapi/cgi/cgi_main.c
+@@ -44,7 +44,9 @@
+ # include <unistd.h>
+ #endif
+ 
++#ifndef WASM_WASI
+ #include <signal.h>
++#endif // WASM_WASI
+ 
+ #include <locale.h>
+ 
+@@ -95,10 +97,12 @@ int __riscosify_control = __RISCOSIFY_STRICT_UNIX_SPECS;
+ # include "valgrind/callgrind.h"
+ #endif
+ 
++#ifndef WASM_WASI
+ #ifndef PHP_WIN32
+ /* XXX this will need to change later when threaded fastcgi is implemented.  shane */
+ struct sigaction act, old_term, old_quit, old_int;
+ #endif
++#endif // WASM_WASI
+ 
+ static void (*php_php_import_environment_variables)(zval *array_ptr);
+ 
+@@ -1456,6 +1460,7 @@ static void init_request_info(fcgi_request *request)
+  */
+ void fastcgi_cleanup(int signal)
+ {
++#ifndef WASM_WASI
+ #ifdef DEBUG_FASTCGI
+ 	fprintf(stderr, "FastCGI shutdown, pid %d\n", getpid());
+ #endif
+@@ -1470,6 +1475,9 @@ void fastcgi_cleanup(int signal)
+ 	} else {
+ 		exit(0);
+ 	}
++#else
++	exit(0);
++#endif // WASM_WASI
+ }
+ #else
+ BOOL WINAPI fastcgi_cleanup(DWORD sig)
+@@ -1765,7 +1773,9 @@ int main(int argc, char *argv[])
+ # endif
+ #endif
+ 
++#ifndef WASM_WASI
+ 	zend_signal_startup();
++#endif // WASM_WASI
+ 
+ #ifdef ZTS
+ 	ts_allocate_id(&php_cgi_globals_id, sizeof(php_cgi_globals_struct), (ts_allocate_ctor) php_cgi_globals_ctor, NULL);
+@@ -1872,6 +1882,7 @@ int main(int argc, char *argv[])
+ 		return FAILURE;
+ 	}
+ 
++#ifndef WASM_WASI
+ 	/* check force_cgi after startup, so we have proper output */
+ 	if (cgi && CGIG(force_redirect)) {
+ 		/* Apache will generate REDIRECT_STATUS,
+@@ -1912,6 +1923,7 @@ consult the installation file that came with this distribution, or visit \n\
+ 			return FAILURE;
+ 		}
+ 	}
++#endif // WASM_WASI
+ 
+ #ifndef HAVE_ATTRIBUTE_WEAK
+ 	fcgi_set_logger(fcgi_log);
+@@ -1988,12 +2000,17 @@ consult the installation file that came with this distribution, or visit \n\
+ 			pid_t pid;
+ 
+ 			/* Create a process group for us & children */
++#ifndef WASM_WASI
+ 			setsid();
+ 			pgroup = getpgrp();
++#else
++			pgroup = 0;
++#endif // WASM_WASI
+ #ifdef DEBUG_FASTCGI
+ 			fprintf(stderr, "Process group %d\n", pgroup);
+ #endif
+ 
++#ifndef WASM_WASI
+ 			/* Set up handler to kill children upon exit */
+ 			act.sa_flags = 0;
+ 			act.sa_handler = fastcgi_cleanup;
+@@ -2004,6 +2021,7 @@ consult the installation file that came with this distribution, or visit \n\
+ 				perror("Can't set signals");
+ 				exit(1);
+ 			}
++#endif // WASM_WASI
+ 
+ 			if (fcgi_in_shutdown()) {
+ 				goto parent_out;
+@@ -2014,7 +2032,11 @@ consult the installation file that came with this distribution, or visit \n\
+ #ifdef DEBUG_FASTCGI
+ 					fprintf(stderr, "Forking, %d running\n", running);
+ #endif
++#ifndef WASM_WASI
+ 					pid = fork();
++#else
++					pid = 1;
++#endif // WASM_WASI
+ 					switch (pid) {
+ 					case 0:
+ 						/* One of the children.
+@@ -2023,11 +2045,13 @@ consult the installation file that came with this distribution, or visit \n\
+ 						 */
+ 						parent = 0;
+ 
++#ifndef WASM_WASI
+ 						/* don't catch our signals */
+ 						sigaction(SIGTERM, &old_term, 0);
+ 						sigaction(SIGQUIT, &old_quit, 0);
+ 						sigaction(SIGINT,  &old_int,  0);
+ 						zend_signal_init();
++#endif // WASM_WASI
+ 						break;
+ 					case -1:
+ 						perror("php (pre-forking)");
+@@ -2046,12 +2070,14 @@ consult the installation file that came with this distribution, or visit \n\
+ #endif
+ 					parent_waiting = 1;
+ 					while (1) {
++#ifndef WASM_WASI
+ 						if (wait(&status) >= 0) {
+ 							running--;
+ 							break;
+ 						} else if (exit_signal) {
+ 							break;
+ 						}
++#endif // WASM_WASI
+ 					}
+ 					if (exit_signal) {
+ #if 0
+diff --git a/sapi/fpm/fpm/fpm_unix.c b/sapi/fpm/fpm/fpm_unix.c
+index 333265b07b..cdee0e7eba 100644
+--- a/sapi/fpm/fpm/fpm_unix.c
++++ b/sapi/fpm/fpm/fpm_unix.c
+@@ -9,7 +9,9 @@
+ #include <unistd.h>
+ #include <sys/types.h>
+ #include <pwd.h>
++#ifdef HAVE_GRP_H
+ #include <grp.h>
++#endif
+ 
+ #ifdef HAVE_PRCTL
+ #include <sys/prctl.h>
+diff --git a/sapi/litespeed/lsapilib.c b/sapi/litespeed/lsapilib.c
+index 2208bbd47b..26d0d307b1 100644
+--- a/sapi/litespeed/lsapilib.c
++++ b/sapi/litespeed/lsapilib.c
+@@ -65,7 +65,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <sys/time.h>
+ #include <sys/uio.h>
+ #include <sys/wait.h>
++#ifdef HAVE_GRP_H
+ #include <grp.h>
++#endif
+ #include <pwd.h>
+ #include <time.h>
+ #include <unistd.h>
+-- 
+2.38.1
+

--- a/php/php-8.2.0/patches/0002-feat-Incapacitate-fibers-when-compiling-for-WASI.patch
+++ b/php/php-8.2.0/patches/0002-feat-Incapacitate-fibers-when-compiling-for-WASI.patch
@@ -1,0 +1,85 @@
+From 60d1ba4112181cc071ac3317424da057290d74eb Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Tue, 3 Jan 2023 17:02:38 +0200
+Subject: [PATCH 2/5] feat: Incapacitate fibers when compiling for WASI
+
+  26.2% Zend/
+
+  26.2% Zend/
+diff --git a/Zend/zend_fibers.c b/Zend/zend_fibers.c
+index 0bc4e0c676..772d379dd8 100644
+--- a/Zend/zend_fibers.c
++++ b/Zend/zend_fibers.c
+@@ -347,12 +347,14 @@ ZEND_API bool zend_fiber_init_context(zend_fiber_context *context, void *kind, z
+ 	makecontext(handle, (void (*)(void)) zend_fiber_trampoline, 0);
+ 
+ 	context->handle = handle;
+-#else
++#elif !defined(__wasi__)
+ 	// Stack grows down, calculate the top of the stack. make_fcontext then shifts pointer to lower 16-byte boundary.
+ 	void *stack = (void *) ((uintptr_t) context->stack->pointer + context->stack->size);
+ 
+ 	context->handle = make_fcontext(stack, context->stack->size, zend_fiber_trampoline);
+ 	ZEND_ASSERT(context->handle != NULL && "make_fcontext() never returns NULL");
++#else
++	return false;
+ #endif
+ 
+ 	context->kind = kind;
+@@ -427,16 +429,18 @@ ZEND_API void zend_fiber_switch_context(zend_fiber_transfer *transfer)
+ 
+ 	/* Copy transfer struct because it might live on the other fiber's stack that will eventually be destroyed. */
+ 	*transfer = *transfer_data;
+-#else
++#elif !defined(__wasi__)
+ 	boost_context_data data = jump_fcontext(to->handle, transfer);
+ 
+ 	/* Copy transfer struct because it might live on the other fiber's stack that will eventually be destroyed. */
+ 	*transfer = *data.transfer;
++#else
++	return;
+ #endif
+ 
+ 	to = transfer->context;
+ 
+-#ifndef ZEND_FIBER_UCONTEXT
++#if !defined(ZEND_FIBER_UCONTEXT) && !defined(__wasi__)
+ 	/* Get the context that resumed us and update its handle to allow for symmetric coroutines. */
+ 	to->handle = data.handle;
+ #endif
+diff --git a/configure.ac b/configure.ac
+index 009e8f88e9..f8088c3a94 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -197,6 +197,9 @@ label2:
+ fi
+ PHP_SUBST(RE2C_FLAGS)
+ 
++dnl Check if __wasi__ is defined by the compiler
++AC_CHECK_DECLS([__wasi__])
++
+ dnl Platform-specific compile settings.
+ dnl ----------------------------------------------------------------------------
+ 
+@@ -1300,11 +1303,13 @@ else
+   if test "$fiber_os" = 'mac'; then
+     AC_DEFINE([_XOPEN_SOURCE], 1, [ ])
+   fi
+-  AC_CHECK_HEADER(ucontext.h, [
+-    AC_DEFINE([ZEND_FIBER_UCONTEXT], 1, [ ])
+-  ], [
+-       AC_MSG_ERROR([fibers not available on this platform])
+-  ])
++  if test "$ac_cv_have_decl___wasi__" != "yes"; then
++    AC_CHECK_HEADER(ucontext.h, [
++      AC_DEFINE([ZEND_FIBER_UCONTEXT], 1, [ ])
++    ], [
++        AC_MSG_ERROR([fibers not available on this platform])
++    ])
++  fi
+ fi
+ 
+ LIBZEND_BASIC_CHECKS
+-- 
+2.38.1
+

--- a/php/php-8.2.0/patches/0003-fix-Add-more-ifdefs-for-php-8.2.0.patch
+++ b/php/php-8.2.0/patches/0003-fix-Add-more-ifdefs-for-php-8.2.0.patch
@@ -1,0 +1,45 @@
+From 4110cce86c84bc5df75d23675d6a2398a4baea0a Mon Sep 17 00:00:00 2001
+From: "no-reply@wasmlabs.dev" <Wasm Labs Team>
+Date: Fri, 6 Jan 2023 11:04:53 +0200
+Subject: [PATCH 3/5] fix: Add more ifdefs for php-8.2.0
+
+
+  43.3% ext/standard/
+  56.6% main/
+diff --git a/ext/standard/basic_functions_arginfo.h b/ext/standard/basic_functions_arginfo.h
+index a5b7b9a0dc..adacedd9f8 100644
+--- a/ext/standard/basic_functions_arginfo.h
++++ b/ext/standard/basic_functions_arginfo.h
+@@ -3634,6 +3634,7 @@ static void register_basic_functions_symbols(int module_number)
+ 	REGISTER_LONG_CONSTANT("IMAGETYPE_AVIF", IMAGE_FILETYPE_AVIF, CONST_PERSISTENT);
+ 	REGISTER_LONG_CONSTANT("IMAGETYPE_UNKNOWN", IMAGE_FILETYPE_UNKNOWN, CONST_PERSISTENT);
+ 	REGISTER_LONG_CONSTANT("IMAGETYPE_COUNT", IMAGE_FILETYPE_COUNT, CONST_PERSISTENT);
++#ifndef __wasi__
+ 	REGISTER_LONG_CONSTANT("LOG_EMERG", LOG_EMERG, CONST_PERSISTENT);
+ 	REGISTER_LONG_CONSTANT("LOG_ALERT", LOG_ALERT, CONST_PERSISTENT);
+ 	REGISTER_LONG_CONSTANT("LOG_CRIT", LOG_CRIT, CONST_PERSISTENT);
+@@ -3695,6 +3696,7 @@ static void register_basic_functions_symbols(int module_number)
+ #if defined(LOG_PERROR)
+ 	REGISTER_LONG_CONSTANT("LOG_PERROR", LOG_PERROR, CONST_PERSISTENT);
+ #endif
++#endif // __wasi__
+ 	REGISTER_LONG_CONSTANT("STR_PAD_LEFT", PHP_STR_PAD_LEFT, CONST_PERSISTENT);
+ 	REGISTER_LONG_CONSTANT("STR_PAD_RIGHT", PHP_STR_PAD_RIGHT, CONST_PERSISTENT);
+ 	REGISTER_LONG_CONSTANT("STR_PAD_BOTH", PHP_STR_PAD_BOTH, CONST_PERSISTENT);
+diff --git a/main/network.c b/main/network.c
+index 6fb97865cb..683e11d03d 100644
+--- a/main/network.c
++++ b/main/network.c
+@@ -929,7 +929,9 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
+ #ifdef IP_BIND_ADDRESS_NO_PORT
+ 			{
+ 				int val = 1;
++#ifndef __wasi__
+ 				(void) setsockopt(sock, SOL_IP, IP_BIND_ADDRESS_NO_PORT, &val, sizeof(val));
++#endif // !defined(__wasi__)o
+ 			}
+ #endif
+ 			if (local_address_len == 0) {
+-- 
+2.38.1
+

--- a/php/php-8.2.0/patches/0004-fix-Fix-memory-issues-and-introduce-WASM_WASMEDGE.patch
+++ b/php/php-8.2.0/patches/0004-fix-Fix-memory-issues-and-introduce-WASM_WASMEDGE.patch
@@ -1,0 +1,68 @@
+From c11343977c9e0cdc72d48e7f20c2f76801a80d2e Mon Sep 17 00:00:00 2001
+From: "no-reply@wasmlabs.dev" <Wasm Labs Team>
+Date: Fri, 6 Jan 2023 11:21:03 +0200
+Subject: [PATCH 4/5] fix: Fix memory issues and introduce WASM_WASMEDGE.
+
+
+  76.4% Zend/
+  11.4% ext/posix/
+  12.1% ext/standard/
+diff --git a/Zend/zend_alloc.c b/Zend/zend_alloc.c
+index 5e67345c76..258766a5d0 100644
+--- a/Zend/zend_alloc.c
++++ b/Zend/zend_alloc.c
+@@ -465,8 +465,8 @@ static void *zend_mm_mmap(size_t size)
+ 	}
+ 	return ptr;
+ #elif ! HAVE_MMAP
+-	void* ptr = malloc(size);
+-	memset(ptr, 0, size);
++	void* ptr = malloc(size + ZEND_MMAP_AHEAD);
++	memset(ptr, 0, size + ZEND_MMAP_AHEAD);
+ 	return ptr;
+ #else
+ 	void *ptr;
+@@ -697,8 +697,8 @@ static zend_always_inline void zend_mm_hugepage(void* ptr, size_t size)
+ static void *zend_mm_chunk_alloc_int(size_t size, size_t alignment)
+ {
+ #if ! HAVE_MMAP
+-	void* ptr = aligned_alloc(alignment, size);
+-	memset(ptr, 0, size);
++	void* ptr = aligned_alloc(alignment, size + ZEND_MMAP_AHEAD);
++	memset(ptr, 0, size + ZEND_MMAP_AHEAD);
+ 	return ptr;
+ #else
+ 	void *ptr = zend_mm_mmap(size);
+diff --git a/ext/posix/posix.c b/ext/posix/posix.c
+index 49806f2cb4..c5e5c4a06e 100644
+--- a/ext/posix/posix.c
++++ b/ext/posix/posix.c
+@@ -536,8 +536,12 @@ PHP_FUNCTION(posix_ttyname)
+ 		RETURN_FALSE;
+ 	}
+ #endif
++#else
++	p = emalloc(1);
++	*p = '\0';
+ #endif // WASM_WASI
+ 	RETURN_STRING("");
++	efree(p);
+ }
+ /* }}} */
+ 
+diff --git a/ext/standard/basic_functions.c b/ext/standard/basic_functions.c
+index e3e443b48b..d367dd8e42 100755
+--- a/ext/standard/basic_functions.c
++++ b/ext/standard/basic_functions.c
+@@ -70,6 +70,8 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
+ #else
+ #include "win32/inet.h"
+ #endif
++#elif defined(WASM_WASMEDGE)
++# include <netdb.h>
+ #endif // WASM_WASI
+ 
+ #ifdef HAVE_ARPA_INET_H
+-- 
+2.38.1
+

--- a/php/php-8.2.0/patches/0005-feat-Server-sockets-via-with-wasm-runtime-wasmedge.patch
+++ b/php/php-8.2.0/patches/0005-feat-Server-sockets-via-with-wasm-runtime-wasmedge.patch
@@ -1,0 +1,1091 @@
+From 79e10bdf096b6a73d4ab730e41c958a70265867b Mon Sep 17 00:00:00 2001
+From: "no-reply@wasmlabs.dev" <Wasm Labs Team>
+Date: Fri, 6 Jan 2023 12:38:11 +0200
+Subject: [PATCH 5/5] feat: Server sockets via --with-wasm-runtime=wasmedge
+
+
+   8.3% sapi/cli/
+  88.4% wasmedge_stubs/
+diff --git a/configure.ac b/configure.ac
+index f8088c3a94..56e95d01c3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -787,6 +787,28 @@ fi
+ dnl Check for openpty. It may require linking against libutil or libbsd.
+ PHP_CHECK_FUNC(openpty, util, bsd)
+ 
++dnl Check wasm runtime.
++PHP_ARG_WITH([wasm-runtime],
++  [whether to build for a specific wasm runtime],
++  [AS_HELP_STRING([--with-wasm-runtime=RUNTIME],
++    [Build with support for specific runtime. Can be either 'default' or 'wasmedge' [default]])],
++  [default],
++  [no])
++
++if test "$PHP_WASM_RUNTIME" != "default"; then
++  case $host_alias in
++    *wasm*)
++      if test "$PHP_WASM_RUNTIME" = "wasmedge"; then
++        PHP_ADD_SOURCES(wasmedge_stubs, wasi_socket_ext.c, -DWASM_RUNTIME_WASMEDGE)
++        CFLAGS="$CFLAGS -DWASM_RUNTIME_WASMEDGE"
++      fi
++      ;;
++    *)
++      AC_MSG_ERROR([--with-wasm-runtime has meaning only for wasm builds!])
++    ;;
++  esac
++fi
++
+ dnl General settings.
+ dnl ----------------------------------------------------------------------------
+ PHP_CONFIGURE_PART(General settings)
+diff --git a/ext/standard/basic_functions.c b/ext/standard/basic_functions.c
+index d367dd8e42..3c241d0115 100755
+--- a/ext/standard/basic_functions.c
++++ b/ext/standard/basic_functions.c
+@@ -70,8 +70,8 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
+ #else
+ #include "win32/inet.h"
+ #endif
+-#elif defined(WASM_WASMEDGE)
+-# include <netdb.h>
++#elif defined(WASM_RUNTIME_WASMEDGE)
++# include "wasmedge_stubs/netdb.h"
+ #endif // WASM_WASI
+ 
+ #ifdef HAVE_ARPA_INET_H
+diff --git a/main/php_network.h b/main/php_network.h
+index a3b7ba7ab3..8ca945f978 100644
+--- a/main/php_network.h
++++ b/main/php_network.h
+@@ -230,7 +230,7 @@ static inline bool _php_check_fd_setsize(php_socket_t *max_fd, int setsize)
+ 	return true;
+ }
+ 
+-#ifdef PHP_WIN32
++#if defined(PHP_WIN32) || defined(__wasi__)
+ /* it is safe to FD_SET too many fd's under win32; the macro will simply ignore
+  * descriptors that go beyond the default FD_SETSIZE */
+ # define PHP_SAFE_FD_SET(fd, set)	FD_SET(fd, set)
+diff --git a/sapi/cli/php_cli_server.c b/sapi/cli/php_cli_server.c
+index ce3ff5de6c..ffbe2f7185 100644
+--- a/sapi/cli/php_cli_server.c
++++ b/sapi/cli/php_cli_server.c
+@@ -97,6 +97,19 @@
+ #include "php_cli_process_title.h"
+ #include "php_cli_process_title_arginfo.h"
+ 
++#ifdef WASM_RUNTIME_WASMEDGE
++#include "wasmedge_stubs/netdb.h"
++#include "wasmedge_stubs/wasi_socket_ext.h"
++#endif
++
++// #define WASMEDGE_SOCKET_DEBUG
++
++#ifdef WASMEDGE_SOCKET_DEBUG
++#define WSEDEBUG(fmt, ...) fprintf(stderr, fmt __VA_OPT__(,) __VA_ARGS__)
++#else
++#define WSEDEBUG(fmt, ...)
++#endif
++
+ #define OUTPUT_NOT_CHECKED -1
+ #define OUTPUT_IS_TTY 1
+ #define OUTPUT_NOT_TTY 0
+@@ -759,7 +772,7 @@ static void sapi_cli_server_log_write(int type, const char *msg) /* {{{ */
+ 			memmove(buf, "unknown", sizeof("unknown"));
+ 		}
+ 	}
+-#ifdef HAVE_FORK
++#if HAVE_FORK
+ 	if (php_cli_server_workers_max > 1) {
+ 		fprintf(stderr, "[%ld] [%s] %s\n", (long) getpid(), buf, msg);
+ 	} else {
+@@ -838,6 +851,24 @@ static void php_cli_server_poller_remove(php_cli_server_poller *poller, int mode
+ 	}
+ #ifndef PHP_WIN32
+ 	if (fd == poller->max_fd) {
++#ifdef WASM_RUNTIME_WASMEDGE
++		php_socket_t new_max_fd = 0;
++
++		for (int i=0; i< poller->rfds.__nfds; ++i)
++		{
++			int candidate = poller->rfds.__fds[i];
++			if(candidate > new_max_fd)
++				new_max_fd = candidate;
++			}
++
++		for (int i=0; i< poller->wfds.__nfds; ++i)
++		{
++			int candidate = poller->wfds.__fds[i];
++			if(candidate > new_max_fd)
++				new_max_fd = candidate;
++		}
++		poller->max_fd = new_max_fd;
++#else
+ 		while (fd > 0) {
+ 			fd--;
+ 			if (PHP_SAFE_FD_ISSET(fd, &poller->rfds) || PHP_SAFE_FD_ISSET(fd, &poller->wfds)) {
+@@ -845,6 +876,7 @@ static void php_cli_server_poller_remove(php_cli_server_poller *poller, int mode
+ 			}
+ 		}
+ 		poller->max_fd = fd;
++#endif
+ 	}
+ #endif
+ } /* }}} */
+@@ -904,6 +936,27 @@ static zend_result php_cli_server_poller_iter_on_active(php_cli_server_poller *p
+ 	php_socket_t fd;
+ 	const php_socket_t max_fd = poller->max_fd;
+ 
++#ifdef WASM_RUNTIME_WASMEDGE
++	// Note this does not keep the order in terms of fd number, when there are both r and w
++
++	for (int i = 0; i < poller->active.rfds.__nfds; ++i)
++	{
++		fd = poller->active.rfds.__fds[i];
++		if (SUCCESS != callback(opaque, fd, POLLIN))
++		{
++			retval = FAILURE;
++		}
++	}
++
++	for (int i = 0; i < poller->active.wfds.__nfds; ++i)
++	{
++		fd = poller->active.wfds.__fds[i];
++		if (SUCCESS != callback(opaque, fd, POLLOUT))
++		{
++			retval = FAILURE;
++		}
++	}
++#else
+ 	for (fd=0 ; fd<=max_fd ; fd++)  {
+ 		if (PHP_SAFE_FD_ISSET(fd, &poller->active.rfds)) {
+ 				if (SUCCESS != callback(opaque, fd, POLLIN)) {
+@@ -916,6 +969,7 @@ static zend_result php_cli_server_poller_iter_on_active(php_cli_server_poller *p
+ 				}
+ 		}
+ 	}
++#endif // WASM_RUNTIME_WASMEDGE
+ #endif
+ 	return retval;
+ } /* }}} */
+@@ -1265,7 +1319,21 @@ static php_socket_t php_network_listen_socket(const char *host, int *port, int s
+ 
+ 	int num_addrs = php_network_getaddresses(host, socktype, &sal, errstr);
+ 	if (num_addrs == 0) {
++#ifdef WASM_RUNTIME_WASMEDGE
++		// This is attempt to copy-paste and initialize the addresses based on the code in php_network_getaddresses,
++		// but I failed to get it right, so it is abandoned (see the commented out free calls at the end of the method)
++		*sal = safe_emalloc(2, sizeof(*sal), 0);
++		struct sockaddr **sap;
++		sap = *sal;
++		*sap = emalloc(sizeof(struct sockaddr_in));
++		(*sap)->sa_family = AF_INET;
++		((struct sockaddr_in *)*sap)->sin_addr.s_addr = INADDR_ANY;
++		((struct sockaddr_in *)*sap)->sin_port = *port;
++		++sap;
++		*sap = NULL;
++#else
+ 		return -1;
++#endif
+ 	}
+ 	for (p = sal; *p; p++) {
+ 		if (sa) {
+@@ -1273,11 +1341,19 @@ static php_socket_t php_network_listen_socket(const char *host, int *port, int s
+ 			sa = NULL;
+ 		}
+ 
++#ifdef WASM_RUNTIME_WASMEDGE
++		(*p)->sa_family = AF_INET;
++#endif
++
+ 		retval = socket((*p)->sa_family, socktype, 0);
+ 		if (retval == SOCK_ERR) {
+ 			continue;
+ 		}
+ 
++#ifdef WASM_RUNTIME_WASMEDGE
++		(*p)->sa_family = AF_INET;
++#endif
++
+ 		switch ((*p)->sa_family) {
+ #if HAVE_GETADDRINFO && HAVE_IPV6
+ 		case AF_INET6:
+@@ -1289,8 +1365,15 @@ static php_socket_t php_network_listen_socket(const char *host, int *port, int s
+ #endif
+ 		case AF_INET:
+ 			sa = pemalloc(sizeof(struct sockaddr_in), 1);
++#ifdef WASM_RUNTIME_WASMEDGE
++			memset(sa, 0, sizeof(struct sockaddr_in));
++			((struct sockaddr_in *)sa)->sin_family = AF_INET;
++			((struct sockaddr_in *)sa)->sin_addr.s_addr = INADDR_ANY;
++			((struct sockaddr_in *)sa)->sin_port = *port;
++#else 
+ 			*(struct sockaddr_in *)sa = *(struct sockaddr_in *)*p;
+ 			((struct sockaddr_in *)sa)->sin_port = htons(*port);
++#endif
+ 			*socklen = sizeof(struct sockaddr_in);
+ 			break;
+ 		default:
+@@ -1320,10 +1403,12 @@ static php_socket_t php_network_listen_socket(const char *host, int *port, int s
+ 
+ 		*af = sa->sa_family;
+ 		if (*port == 0) {
++#ifndef WASM_RUNTIME_WASMEDGE
+ 			if (getsockname(retval, sa, socklen)) {
+ 				err = php_socket_errno();
+ 				goto out;
+ 			}
++#endif
+ 			switch (sa->sa_family) {
+ #if HAVE_GETADDRINFO && HAVE_IPV6
+ 			case AF_INET6:
+@@ -1349,12 +1434,14 @@ static php_socket_t php_network_listen_socket(const char *host, int *port, int s
+ 	}
+ 
+ out:
++#ifndef WASM_RUNTIME_WASMEDGE
+ 	if (sa) {
+ 		pefree(sa, 1);
+ 	}
+ 	if (sal) {
+ 		php_network_freeaddresses(sal);
+ 	}
++#endif
+ 	if (err) {
+ 		if (ZEND_VALID_SOCKET(retval)) {
+ 			closesocket(retval);
+diff --git a/wasmedge_stubs/netdb.h b/wasmedge_stubs/netdb.h
+new file mode 100644
+index 0000000000..c1136150b7
+--- /dev/null
++++ b/wasmedge_stubs/netdb.h
+@@ -0,0 +1,73 @@
++#pragma once
++// Based on https://github.com/hangedfish/wasmedge_wasi_socket_c
++
++struct addrinfo {
++	int ai_flags;
++	int ai_family;
++	int ai_socktype;
++	int ai_protocol;
++	socklen_t ai_addrlen;
++	struct sockaddr *ai_addr;
++	char *ai_canonname;
++    int ai_canonnamelen;
++	struct addrinfo *ai_next;
++};
++
++#define AI_PASSIVE      0x00
++#define AI_CANONNAME    0x01
++#define AI_NUMERICHOST  0x02
++#define AI_NUMERICSERV  0x03
++#define AI_V4MAPPED     0x04
++#define AI_ALL          0x05
++#define AI_ADDRCONFIG   0x06
++
++
++#define NI_NUMERICHOST  0x01
++#define NI_NUMERICSERV  0x02
++#define NI_NOFQDN       0x04
++#define NI_NAMEREQD     0x08
++#define NI_DGRAM        0x10
++#define NI_NUMERICSCOPE 0x100
++
++#define EAI_BADFLAGS   -1
++#define EAI_NONAME     -2
++#define EAI_AGAIN      -3
++#define EAI_FAIL       -4
++#define EAI_FAMILY     -6
++#define EAI_SOCKTYPE   -7
++#define EAI_SERVICE    -8
++#define EAI_MEMORY     -10
++#define EAI_SYSTEM     -11
++#define EAI_OVERFLOW   -12
++
++#define EAI_NODATA     -5
++#define EAI_ADDRFAMILY -9
++#define EAI_INPROGRESS -100
++#define EAI_CANCELED   -101
++#define EAI_NOTCANCELED -102
++#define EAI_ALLDONE    -103
++#define EAI_INTR       -104
++#define EAI_IDN_ENCODE -105
++#define NI_MAXHOST 255
++#define NI_MAXSERV 32
++
++struct servent {
++	char *s_name;
++	char **s_aliases;
++	int s_port;
++	char *s_proto;
++};
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++struct servent *getservbyname (const char *, const char *);
++
++int getaddrinfo (const char *__restrict, const char *__restrict, const struct addrinfo *__restrict, struct addrinfo **__restrict);
++void freeaddrinfo (struct addrinfo *);
++// int getnameinfo (const struct sockaddr *__restrict, socklen_t, char *__restrict, socklen_t, char *__restrict, socklen_t, int);
++
++#ifdef __cplusplus
++}
++#endif
+\ No newline at end of file
+diff --git a/wasmedge_stubs/wasi_socket_ext.c b/wasmedge_stubs/wasi_socket_ext.c
+new file mode 100644
+index 0000000000..0c74c75a5e
+--- /dev/null
++++ b/wasmedge_stubs/wasi_socket_ext.c
+@@ -0,0 +1,406 @@
++// Based on https://github.com/hangedfish/wasmedge_wasi_socket_c
++
++#include "wasi_socket_ext.h"
++#include "netdb.h"
++#include <errno.h>
++#include <memory.h>
++#include <netinet/in.h>
++#include <stdint.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++// #define WASMEDGE_SOCKET_DEBUG
++
++#ifdef WASMEDGE_SOCKET_DEBUG
++#define WSEDEBUG(fmt, ...) fprintf(stderr, fmt __VA_OPT__(,) __VA_ARGS__)
++#else
++#define WSEDEBUG(fmt, ...)
++#endif
++
++// WasmEdge Socket API
++
++#define kUnspec 0
++#define kInet4 1
++#define kInet6 2
++
++typedef uint8_t address_family_t;
++
++#define kAny 0
++#define kDatagram 1
++#define kStream 2
++
++typedef uint8_t socket_type_t;
++
++#define kIPProtoIP 0
++#define kIPProtoTCP 1
++#define kIPProtoUDP 2
++
++typedef uint32_t ai_protocol_t;
++
++#define kAiPassive 0
++#define kAiCanonname 1
++#define kAiNumericHost 2
++#define kAiNumericServ = 4
++#define kAiV4Mapped = 8
++#define kAiAll = 16
++#define kAiAddrConfig = 32
++
++typedef uint16_t ai_flags_t;
++
++typedef struct wasi_address {
++  uint8_t *buf;
++  uint32_t size;
++} wasi_address_t;
++
++typedef struct iovec_read {
++  uint8_t *buf;
++  uint32_t size;
++} iovec_read_t;
++
++typedef struct iovec_write {
++  uint8_t *buf;
++  uint32_t size;
++} iovec_write_t;
++
++typedef struct wasi_sockaddr {
++  address_family_t family;
++  uint32_t sa_data_len;
++  uint8_t *sa_data;
++} wasi_sockaddr_t;
++
++typedef struct wasi_canonname_buff {
++  char name[30];
++} wasi_canonname_buff_t;
++
++#pragma pack(push, 1)
++typedef struct wasi_addrinfo {
++  ai_flags_t ai_flags;
++  address_family_t ai_family;
++  socket_type_t ai_socktype;
++  ai_protocol_t ai_protocol;
++  uint32_t ai_addrlen;
++  wasi_sockaddr_t *ai_addr;
++  char *ai_canonname;
++  uint32_t ai_canonnamelen;
++  struct wasi_addrinfo *ai_next;
++} wasi_addrinfo_t;
++#pragma pack(pop)
++
++typedef struct sockaddr_generic {
++  union sa {
++    struct sockaddr_in sin;
++    struct sockaddr_in6 sin6;
++  } sa;
++
++} sa_t;
++
++#define MAX_ADDRINFO_RES_LEN 10
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_open(
++    uint8_t addr_family, uint8_t sock_type, int32_t *fd)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_open")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_bind(
++    uint32_t fd, wasi_address_t *addr, uint32_t port)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_bind")));
++
++uint32_t
++__imported_wasmedge_wasi_snapshot_preview1_sock_listen(uint32_t fd,
++                                                       uint32_t backlog)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_listen")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_accept(uint32_t fd,
++                                                               uint32_t *fd2)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_accept")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_connect(
++    uint32_t fd, wasi_address_t *addr, uint32_t port)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_connect")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_recv(
++    uint32_t fd, iovec_read_t *buf, uint32_t buf_len, uint16_t flags,
++    uint32_t *recv_len, uint32_t *oflags)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_recv")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_recv_from(
++    uint32_t fd, iovec_read_t *buf, uint32_t buf_len, uint8_t *addr,
++    uint32_t *addr_len, uint16_t flags)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_recv_from")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_send(uint32_t fd,
++                                                             iovec_write_t buf,
++                                                             uint32_t buf_len,
++                                                             uint16_t flags,
++                                                             uint32_t *send_len)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_send")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_send_to(
++    uint32_t fd, uint8_t *buf, uint32_t buf_len, uint8_t *addr,
++    uint32_t addr_len, uint16_t flags)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_send_to")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_shutdown(uint32_t fd,
++                                                                 uint8_t flags)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_shutdown")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_getaddrinfo(
++    uint8_t *node, uint32_t node_len, uint8_t *server, uint32_t server_len,
++    wasi_addrinfo_t *hint, uint32_t *res, uint32_t max_len, uint32_t *res_len)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_getaddrinfo")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_getpeeraddr(
++    uint32_t fd, wasi_address_t *addr, uint32_t *addr_type, uint32_t *port)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_getpeeraddr")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_getlocaladdr(
++    uint32_t fd, wasi_address_t *addr, uint32_t *addr_type, uint32_t *port)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_getlocaladdr")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_getsockopt(
++    uint32_t fd, int32_t level, int32_t name, int32_t *flag,
++    uint32_t *flag_size)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_getsockopt")));
++
++int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_setsockopt(
++    uint32_t fd, int32_t level, int32_t name, int32_t *flag,
++    uint32_t *flag_size)
++    __attribute__((__import_module__("wasi_snapshot_preview1"),
++                   __import_name__("sock_getsockopt")));
++
++int socket(int domain, int type, int protocol)
++{
++  int fd;
++  address_family_t af = (domain == AF_INET ? kInet4 : kInet6);
++  socket_type_t st = (type == SOCK_STREAM ? kStream : kDatagram);
++  int res = __imported_wasmedge_wasi_snapshot_preview1_sock_open((int8_t)af, (int8_t)st, &fd);
++  if (0 != res) {
++    errno = res;
++    printf("socket err: %s \n", strerror(errno));
++    return -1;
++  }
++  WSEDEBUG("WWSock| socket returning: %d \n", fd);
++  return fd;
++}
++
++int bind(int fd, const struct sockaddr *addr, socklen_t len)
++{
++  WSEDEBUG("WWSock| bind[%d]: calling bind on sa_data=[", __LINE__);
++  for (int i = 0; i < len; ++i)
++    WSEDEBUG("'%d', ", (short)addr->sa_data[i]);
++  WSEDEBUG("]\n");
++
++  wasi_address_t wasi_addr;
++  memset(&wasi_addr, 0, sizeof(wasi_address_t));
++  uint32_t port;
++  if (AF_INET == addr->sa_family) {
++    struct sockaddr_in *sin = (struct sockaddr_in *)addr;
++    wasi_addr.buf = (uint8_t *)&sin->sin_addr;
++    wasi_addr.size = 4;
++    port = sin->sin_port;
++  } else if (AF_INET6 == addr->sa_family) {
++    struct sockaddr_in6 *sin = (struct sockaddr_in6 *)addr;
++    wasi_addr.buf = (uint8_t *)&sin->sin6_addr;
++    wasi_addr.size = 16;
++    port = sin->sin6_port;
++  }
++
++  WSEDEBUG("WWSock| bind[%d]: __imported_wasmedge_wasi_snapshot_preview1_sock_bind\n", __LINE__);
++  int res =
++      __imported_wasmedge_wasi_snapshot_preview1_sock_bind(fd, &wasi_addr, port);
++  WSEDEBUG("WWSock| bind[%d]: res=%d\n", __LINE__, res);
++  if (res != 0)
++  {
++    errno = res;
++    return -1;
++  }
++  return res;
++}
++
++int connect(int fd, const struct sockaddr *addr, socklen_t len) {
++  WSEDEBUG("WWSock| connect[%d]: fd=%d, addr=%d, port=%d \n", __LINE__,
++          fd, ((struct sockaddr_in *)addr)->sin_addr.s_addr, ((struct sockaddr_in *)addr)->sin_port);
++  wasi_address_t wasi_addr;
++  memset(&wasi_addr, 0, sizeof(wasi_address_t));
++  uint32_t port;
++  if (AF_INET == addr->sa_family) {
++    struct sockaddr_in *sin = (struct sockaddr_in *)addr;
++    wasi_addr.buf = (uint8_t *)&sin->sin_addr;
++    wasi_addr.size = 4;
++    port = ntohs(sin->sin_port);
++  } else if (AF_INET6 == addr->sa_family) {
++    struct sockaddr_in6 *sin = (struct sockaddr_in6 *)addr;
++    wasi_addr.buf = (uint8_t *)&sin->sin6_addr;
++    wasi_addr.size = 16;
++    port = ntohs(sin->sin6_port);
++  }
++  int res = __imported_wasmedge_wasi_snapshot_preview1_sock_connect(
++      fd, &wasi_addr, port);
++  if (res != 0) {
++    errno = res;
++    return -1;
++  }
++  return res;
++}
++
++int listen(int fd, int backlog) {
++  WSEDEBUG("WWSock| __imported_wasmedge_wasi_snapshot_preview1_sock_listen[%d]: \n", __LINE__);
++  int res = __imported_wasmedge_wasi_snapshot_preview1_sock_listen(fd, backlog);
++  WSEDEBUG("WWSock| listen[%d]: res=%d\n", __LINE__, res);
++  return res;
++}
++
++int accept(int fd, struct sockaddr *restrict addr, socklen_t *restrict len) {
++  WSEDEBUG("WWSock| accept[%d]: fd=%d\n", __LINE__, fd);
++  int new_sockfd;
++  int res = __imported_wasmedge_wasi_snapshot_preview1_sock_accept(
++      fd, (uint32_t *)&new_sockfd);
++  if (res != 0) {
++    errno = res;
++    return -1;
++  }
++  return new_sockfd;
++}
++
++int setsockopt(int fd, int level, int optname, const void *optval,
++               socklen_t optlen) {
++  WSEDEBUG("WWSock| setsockopt[%d]: fd=%d\n", __LINE__, fd);
++  int res = __imported_wasmedge_wasi_snapshot_preview1_sock_setsockopt(
++      fd, level, optname, (int32_t *)optval, (uint32_t *)&optlen);
++  if (res != 0) {
++    errno = res;
++    return -1;
++  }
++  return 0;
++}
++
++struct servent *getservbyname(const char *name, const char *prots)
++{
++  WSEDEBUG("WWSock| getservbyname[%d]: name=%s\n", __LINE__, name);
++  return NULL;
++}
++
++static struct addrinfo *
++convert_wasi_addrinfo_to_addrinfo(wasi_addrinfo_t *wasi_addrinfo,
++                                  uint32_t size) {
++  WSEDEBUG("WWSock| convert_wasi_addrinfo_to_addrinfo[%d]: \n", __LINE__);
++
++  struct addrinfo *addrinfo_arr = (struct addrinfo *)calloc(
++      (sizeof(struct addrinfo) + sizeof(struct sockaddr_generic)) * size + 30,
++      1);
++  struct sockaddr_generic *sockaddr_generic_arr =
++      (struct sockaddr_generic *)&addrinfo_arr[size];
++  char *ai_canonname = (char *)&sockaddr_generic_arr[size];
++  int ai_canonnamelen = addrinfo_arr[0].ai_canonnamelen;
++  memcpy(ai_canonname, addrinfo_arr[0].ai_canonname, ai_canonnamelen);
++
++  for (size_t i = 0; i < size; i++) {
++    addrinfo_arr[i] = (struct addrinfo){
++        .ai_flags = (int)wasi_addrinfo[i].ai_flags,
++        .ai_family = wasi_addrinfo[i].ai_family == kInet4 ? AF_INET : AF_INET6,
++        .ai_socktype =
++            wasi_addrinfo[i].ai_socktype == kStream ? SOCK_STREAM : SOCK_DGRAM,
++        .ai_protocol = wasi_addrinfo[i].ai_protocol == kIPProtoTCP
++                           ? IPPROTO_TCP
++                           : IPPROTO_UDP,
++        .ai_addrlen = 0,
++        .ai_addr = (struct sockaddr *)&sockaddr_generic_arr[i],
++        .ai_canonname = ai_canonname,
++        .ai_canonnamelen = ai_canonnamelen,
++        .ai_next = NULL,
++    };
++    if (wasi_addrinfo[i].ai_addr != NULL) {
++      if (wasi_addrinfo[i].ai_addr->family == kInet4) {
++        // IPv4
++        wasi_addrinfo[i].ai_addrlen = sizeof(struct sockaddr_in);
++        sockaddr_generic_arr[i].sa.sin.sin_family = AF_INET;
++        sockaddr_generic_arr[i].sa.sin.sin_port =
++            *(uint16_t *)&wasi_addrinfo[i].ai_addr->sa_data[0];
++        sockaddr_generic_arr[i].sa.sin.sin_addr.s_addr =
++            *(in_addr_t *)&wasi_addrinfo[i].ai_addr->sa_data[2];
++      } else {
++        // IPv6
++        wasi_addrinfo[i].ai_addrlen = sizeof(struct sockaddr_in6);
++        sockaddr_generic_arr[i].sa.sin6.sin6_family = AF_INET6;
++        sockaddr_generic_arr[i].sa.sin6.sin6_port =
++            *(uint16_t *)&wasi_addrinfo[i].ai_addr->sa_data[0];
++        // WasmEdge rust socket api not support IPv6 addrinfo.
++        WSEDEBUG("Not support IPv6 addrinfo.");
++        abort();
++      }
++    }
++    if (i > 0) {
++      addrinfo_arr[i - 1].ai_next = &addrinfo_arr[i];
++    }
++  }
++  return addrinfo_arr;
++}
++
++int getaddrinfo(const char *restrict host, const char *restrict serv,
++                const struct addrinfo *restrict hint,
++                struct addrinfo **restrict res) {
++  WSEDEBUG("WWSock| getaddrinfo[%d]: \n", __LINE__);
++  uint32_t res_len = 0;
++  uint8_t *sockbuff = (uint8_t *)calloc(26 * MAX_ADDRINFO_RES_LEN, 1);
++  wasi_sockaddr_t *sockaddr_arr =
++      (wasi_sockaddr_t *)calloc(sizeof(wasi_sockaddr_t) * MAX_ADDRINFO_RES_LEN +
++                                    sizeof(wasi_canonname_buff_t),
++                                1);
++  wasi_addrinfo_t *addrinfo_arr = (wasi_addrinfo_t *)calloc(
++      sizeof(wasi_addrinfo_t) * MAX_ADDRINFO_RES_LEN, 1);
++  for (size_t i = 0; i < MAX_ADDRINFO_RES_LEN; i++) {
++    sockaddr_arr[i].sa_data = &sockbuff[i];
++    addrinfo_arr[i].ai_addr = &sockaddr_arr[i];
++    addrinfo_arr[i].ai_canonname = (char *)&addrinfo_arr[MAX_ADDRINFO_RES_LEN];
++    if (i > 0) {
++      addrinfo_arr[i - 1].ai_next = &addrinfo_arr[i];
++    }
++  }
++  wasi_addrinfo_t wasi_hint = (wasi_addrinfo_t){
++      .ai_flags = (ai_flags_t)hint->ai_flags,
++      .ai_family = hint->ai_family == AF_INET6 ? kInet6 : kInet4,
++      .ai_socktype = hint->ai_socktype == SOCK_DGRAM ? kDatagram : kStream,
++      .ai_protocol =
++          hint->ai_protocol == IPPROTO_UDP ? kIPProtoUDP : kIPProtoTCP,
++      .ai_addrlen = 0,
++      .ai_addr = NULL,
++      .ai_canonname = NULL,
++      .ai_canonnamelen = 0,
++      .ai_next = NULL,
++  };
++
++  int rc = __imported_wasmedge_wasi_snapshot_preview1_sock_getaddrinfo(
++      (uint8_t *)host, strlen(host), (uint8_t *)serv, strlen(serv), &wasi_hint,
++      (uint32_t *)&addrinfo_arr, MAX_ADDRINFO_RES_LEN, &res_len);
++  if (0 != rc) {
++    errno = rc;
++    free((void *)addrinfo_arr);
++    free((void *)sockaddr_arr);
++    free((void *)sockbuff);
++    return -1;
++  }
++  *res = convert_wasi_addrinfo_to_addrinfo(addrinfo_arr, res_len);
++  free(addrinfo_arr);
++  free(sockaddr_arr);
++  free(sockbuff);
++  return 0;
++}
++
++void freeaddrinfo(struct addrinfo *p) {
++  WSEDEBUG("WWSock| freeaddrinfo[%d]: \n", __LINE__);
++  free(p);
++}
+\ No newline at end of file
+diff --git a/wasmedge_stubs/wasi_socket_ext.h b/wasmedge_stubs/wasi_socket_ext.h
+new file mode 100644
+index 0000000000..ee4dc75b43
+--- /dev/null
++++ b/wasmedge_stubs/wasi_socket_ext.h
+@@ -0,0 +1,331 @@
++#pragma once
++// Based on https://github.com/hangedfish/wasmedge_wasi_socket_c
++
++#include <sys/socket.h>
++
++// struct sockaddr_in {
++// 	sa_family_t sin_family;
++// 	in_port_t sin_port;
++// 	struct in_addr sin_addr;
++// 	uint8_t sin_zero[8];
++// };
++
++// struct sockaddr_in6 {
++// 	sa_family_t     sin6_family;
++// 	in_port_t       sin6_port;
++// 	uint32_t        sin6_flowinfo;
++// 	struct in6_addr sin6_addr;
++// 	uint32_t        sin6_scope_id;
++// };
++
++#ifndef SHUT_RD
++#define SHUT_RD 0
++#define SHUT_WR 1
++#define SHUT_RDWR 2
++#endif
++
++// #ifndef SOCK_STREAM
++// #define SOCK_STREAM    1
++// #define SOCK_DGRAM     2
++// #endif
++
++#define SOCK_RAW 3
++#define SOCK_RDM 4
++#define SOCK_SEQPACKET 5
++#define SOCK_DCCP 6
++#define SOCK_PACKET 10
++
++#ifndef SOCK_CLOEXEC
++#define SOCK_CLOEXEC 02000000
++#define SOCK_NONBLOCK 04000
++#endif
++
++#define PF_UNSPEC 0
++#define PF_LOCAL 1
++#define PF_UNIX PF_LOCAL
++#define PF_FILE PF_LOCAL
++#define PF_INET 2
++#define PF_AX25 3
++#define PF_IPX 4
++#define PF_APPLETALK 5
++#define PF_NETROM 6
++#define PF_BRIDGE 7
++#define PF_ATMPVC 8
++#define PF_X25 9
++#define PF_INET6 10
++#define PF_ROSE 11
++#define PF_DECnet 12
++#define PF_NETBEUI 13
++#define PF_SECURITY 14
++#define PF_KEY 15
++#define PF_NETLINK 16
++#define PF_ROUTE PF_NETLINK
++#define PF_PACKET 17
++#define PF_ASH 18
++#define PF_ECONET 19
++#define PF_ATMSVC 20
++#define PF_RDS 21
++#define PF_SNA 22
++#define PF_IRDA 23
++#define PF_PPPOX 24
++#define PF_WANPIPE 25
++#define PF_LLC 26
++#define PF_IB 27
++#define PF_MPLS 28
++#define PF_CAN 29
++#define PF_TIPC 30
++#define PF_BLUETOOTH 31
++#define PF_IUCV 32
++#define PF_RXRPC 33
++#define PF_ISDN 34
++#define PF_PHONET 35
++#define PF_IEEE802154 36
++#define PF_CAIF 37
++#define PF_ALG 38
++#define PF_NFC 39
++#define PF_VSOCK 40
++#define PF_KCM 41
++#define PF_QIPCRTR 42
++#define PF_SMC 43
++#define PF_XDP 44
++#define PF_MAX 45
++
++// #define AF_UNSPEC       PF_UNSPEC
++// #define AF_LOCAL        PF_LOCAL
++// #define AF_UNIX         AF_LOCAL
++// #define AF_FILE         AF_LOCAL
++// #define AF_INET         PF_INET
++// #define AF_AX25         PF_AX25
++// #define AF_IPX          PF_IPX
++// #define AF_APPLETALK    PF_APPLETALK
++// #define AF_NETROM       PF_NETROM
++// #define AF_BRIDGE       PF_BRIDGE
++// #define AF_ATMPVC       PF_ATMPVC
++// #define AF_X25          PF_X25
++// #define AF_INET6        PF_INET6
++// #define AF_ROSE         PF_ROSE
++// #define AF_DECnet       PF_DECnet
++// #define AF_NETBEUI      PF_NETBEUI
++// #define AF_SECURITY     PF_SECURITY
++// #define AF_KEY          PF_KEY
++// #define AF_NETLINK      PF_NETLINK
++// #define AF_ROUTE        PF_ROUTE
++// #define AF_PACKET       PF_PACKET
++// #define AF_ASH          PF_ASH
++// #define AF_ECONET       PF_ECONET
++// #define AF_ATMSVC       PF_ATMSVC
++// #define AF_RDS          PF_RDS
++// #define AF_SNA          PF_SNA
++// #define AF_IRDA         PF_IRDA
++// #define AF_PPPOX        PF_PPPOX
++// #define AF_WANPIPE      PF_WANPIPE
++// #define AF_LLC          PF_LLC
++// #define AF_IB           PF_IB
++// #define AF_MPLS         PF_MPLS
++// #define AF_CAN          PF_CAN
++// #define AF_TIPC         PF_TIPC
++// #define AF_BLUETOOTH    PF_BLUETOOTH
++// #define AF_IUCV         PF_IUCV
++// #define AF_RXRPC        PF_RXRPC
++// #define AF_ISDN         PF_ISDN
++// #define AF_PHONET       PF_PHONET
++// #define AF_IEEE802154   PF_IEEE802154
++// #define AF_CAIF         PF_CAIF
++// #define AF_ALG          PF_ALG
++// #define AF_NFC          PF_NFC
++// #define AF_VSOCK        PF_VSOCK
++// #define AF_KCM          PF_KCM
++// #define AF_QIPCRTR      PF_QIPCRTR
++// #define AF_SMC          PF_SMC
++// #define AF_XDP          PF_XDP
++// #define AF_MAX          PF_MAX
++
++// WasmEdge wasi_sock_opt_so
++#define SO_REUSEADDR 0
++#ifdef SO_TYPE
++#undef SO_TYPE
++#define SO_TYPE 1
++#endif
++#define SO_ERROR 2
++#define SO_DONTROUTE 3
++#define SO_BROADCAST 4
++#ifdef SO_SNDBUF
++#undef SO_SNBBUF
++#define SO_SNDBUF 5
++#endif
++#define SO_RCVBUF 6
++#define SO_KEEPALIVE 7
++#define SO_OOBINLINE 8
++#define SO_LINGER 9
++#define SO_RCVLOWAT 10
++#define SO_RCVTIMEO 11
++#define SO_SNDTIME0 12
++#define SO_ACCEPTCONN 13
++
++// #ifndef SO_DEBUG
++// #define SO_DEBUG        1
++// #define SO_REUSEADDR    2
++// #define SO_TYPE         3
++// #define SO_ERROR        4
++// #define SO_DONTROUTE    5
++// #define SO_BROADCAST    6
++// #define SO_SNDBUF       7
++// #define SO_RCVBUF       8
++// #define SO_KEEPALIVE    9
++// #define SO_OOBINLINE    10
++// #define SO_NO_CHECK     11
++// #define SO_PRIORITY     12
++// #define SO_LINGER       13
++// #define SO_BSDCOMPAT    14
++// #define SO_REUSEPORT    15
++// #define SO_PASSCRED     16
++// #define SO_PEERCRED     17
++// #define SO_RCVLOWAT     18
++// #define SO_SNDLOWAT     19
++// #define SO_ACCEPTCONN   30
++// #define SO_PEERSEC      31
++// #define SO_SNDBUFFORCE  32
++// #define SO_RCVBUFFORCE  33
++// #define SO_PROTOCOL     38
++// #define SO_DOMAIN       39
++// #endif
++
++#ifndef SO_RCVTIMEO
++#if __LONG_MAX == 0x7fffffff
++#define SO_RCVTIMEO 66
++#define SO_SNDTIMEO 67
++#else
++#define SO_RCVTIMEO 20
++#define SO_SNDTIMEO 21
++#endif
++#endif
++
++#ifndef SO_TIMESTAMP
++#if __LONG_MAX == 0x7fffffff
++#define SO_TIMESTAMP 63
++#define SO_TIMESTAMPNS 64
++#define SO_TIMESTAMPING 65
++#else
++#define SO_TIMESTAMP 29
++#define SO_TIMESTAMPNS 35
++#define SO_TIMESTAMPING 37
++#endif
++#endif
++
++#define SO_SECURITY_AUTHENTICATION 22
++#define SO_SECURITY_ENCRYPTION_TRANSPORT 23
++#define SO_SECURITY_ENCRYPTION_NETWORK 24
++
++#define SO_BINDTODEVICE 25
++
++#define SO_ATTACH_FILTER 26
++#define SO_DETACH_FILTER 27
++#define SO_GET_FILTER SO_ATTACH_FILTER
++
++#define SO_PEERNAME 28
++#define SCM_TIMESTAMP SO_TIMESTAMP
++#define SO_PASSSEC 34
++#define SCM_TIMESTAMPNS SO_TIMESTAMPNS
++#define SO_MARK 36
++#define SCM_TIMESTAMPING SO_TIMESTAMPING
++#define SO_RXQ_OVFL 40
++#define SO_WIFI_STATUS 41
++#define SCM_WIFI_STATUS SO_WIFI_STATUS
++#define SO_PEEK_OFF 42
++#define SO_NOFCS 43
++#define SO_LOCK_FILTER 44
++#define SO_SELECT_ERR_QUEUE 45
++#define SO_BUSY_POLL 46
++#define SO_MAX_PACING_RATE 47
++#define SO_BPF_EXTENSIONS 48
++#define SO_INCOMING_CPU 49
++#define SO_ATTACH_BPF 50
++#define SO_DETACH_BPF SO_DETACH_FILTER
++#define SO_ATTACH_REUSEPORT_CBPF 51
++#define SO_ATTACH_REUSEPORT_EBPF 52
++#define SO_CNX_ADVICE 53
++#define SCM_TIMESTAMPING_OPT_STATS 54
++#define SO_MEMINFO 55
++#define SO_INCOMING_NAPI_ID 56
++#define SO_COOKIE 57
++#define SCM_TIMESTAMPING_PKTINFO 58
++#define SO_PEERGROUPS 59
++#define SO_ZEROCOPY 60
++#define SO_TXTIME 61
++#define SCM_TXTIME SO_TXTIME
++#define SO_BINDTOIFINDEX 62
++#define SO_DETACH_REUSEPORT_BPF 68
++
++#ifndef SOL_SOCKET
++#define SOL_SOCKET 1
++#endif
++
++#define SOL_IP 0
++#define SOL_IPV6 41
++#define SOL_ICMPV6 58
++
++#define SOL_RAW 255
++#define SOL_DECNET 261
++#define SOL_X25 262
++#define SOL_PACKET 263
++#define SOL_ATM 264
++#define SOL_AAL 265
++#define SOL_IRDA 266
++#define SOL_NETBEUI 267
++#define SOL_LLC 268
++#define SOL_DCCP 269
++#define SOL_NETLINK 270
++#define SOL_TIPC 271
++#define SOL_RXRPC 272
++#define SOL_PPPOL2TP 273
++#define SOL_BLUETOOTH 274
++#define SOL_PNPIPE 275
++#define SOL_RDS 276
++#define SOL_IUCV 277
++#define SOL_CAIF 278
++#define SOL_ALG 279
++#define SOL_NFC 280
++#define SOL_KCM 281
++#define SOL_TLS 282
++#define SOL_XDP 283
++
++#define SOMAXCONN 128
++
++// #define MSG_OOB       0x0001
++// #define MSG_PEEK      0x0002
++// #define MSG_DONTROUTE 0x0004
++// #define MSG_CTRUNC    0x0008
++// #define MSG_PROXY     0x0010
++// #define MSG_TRUNC     0x0020
++// #define MSG_DONTWAIT  0x0040
++// #define MSG_EOR       0x0080
++// #define MSG_WAITALL   0x0100
++// #define MSG_FIN       0x0200
++// #define MSG_SYN       0x0400
++// #define MSG_CONFIRM   0x0800
++// #define MSG_RST       0x1000
++// #define MSG_ERRQUEUE  0x2000
++// #define MSG_NOSIGNAL  0x4000
++// #define MSG_MORE      0x8000
++// #define MSG_WAITFORONE 0x10000
++// #define MSG_BATCH     0x40000
++// #define MSG_ZEROCOPY  0x4000000
++// #define MSG_FASTOPEN  0x20000000
++// #define MSG_CMSG_CLOEXEC 0x40000000
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++int socket(int, int, int);
++
++int bind(int, const struct sockaddr *, socklen_t);
++int connect(int, const struct sockaddr *, socklen_t);
++int listen(int, int);
++int accept(int, struct sockaddr *__restrict, socklen_t *__restrict);
++
++int setsockopt(int, int, int, const void *, socklen_t);
++
++#ifdef __cplusplus
++}
++#endif
+\ No newline at end of file
+-- 
+2.38.1
+

--- a/php/php-8.2.0/wl-build-deps.sh
+++ b/php/php-8.2.0/wl-build-deps.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+if [ "${BASH_SOURCE-}" = "$0" ]; then
+    echo "You must source this script to add to CFLAGS and LDFLAGS: \$ source $0" >&2
+    return
+fi
+
+logStatus "Building dependencies... "
+
+### sqlite3
+$WASMLABS_MAKE ${WASMLABS_REPO_ROOT}/libs/sqlite/version-3.39.2 || exit 1
+
+export CFLAGS_DEPENDENCIES="-I${WASMLABS_OUTPUT_BASE}/sqlite/version-3.39.2/include ${CFLAGS_DEPENDENCIES}"
+export LDFLAGS_DEPENDENCIES="-L${WASMLABS_OUTPUT_BASE}/sqlite/version-3.39.2/lib ${LDFLAGS_DEPENDENCIES}"

--- a/php/php-8.2.0/wl-build.sh
+++ b/php/php-8.2.0/wl-build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+# export CFLAGS_CONFIG="-O3 -g"
+export CFLAGS_CONFIG="-O2"
+
+########## Setup the wasi related flags #############
+export CFLAGS_WASI="--sysroot=${WASI_SYSROOT} -D_WASI_EMULATED_GETPID -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_PROCESS_CLOCKS"
+export LDFLAGS_WASI="--sysroot=${WASI_SYSROOT} -lwasi-emulated-getpid -lwasi-emulated-signal -lwasi-emulated-process-clocks"
+
+########## Setup the libsql related flags #############
+export CFLAGS_SQLITE='-DSQLITE_OMIT_LOAD_EXTENSION=1'
+export LDFLAGS_SQLITE='-lsqlite3'
+
+########## Setup the flags for php #############
+export CFLAGS_PHP='-D_POSIX_SOURCE=1 -D_GNU_SOURCE=1 -DHAVE_FORK=0 -DWASM_WASI'
+
+# We need to add LDFLAGS ot CFLAGS because autoconf compiles(+links) to binary when checking stuff
+export LDFLAGS="${LDFLAGS_WASI} ${LDFLAGS_DEPENDENCIES} ${LDFLAGS_SQLITE}"
+export CFLAGS="${CFLAGS_CONFIG} ${CFLAGS_WASI} ${CFLAGS_SQLITE} ${CFLAGS_DEPENDENCIES} ${CFLAGS_PHP} ${LDFLAGS}"
+
+cd "${WASMLABS_CHECKOUT_PATH}"
+
+logStatus "Generating configure script... "
+./buildconf --force || exit 1
+
+export PHP_CONFIGURE=' --without-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite --disable-fiber-asm'
+
+if [[ -v WASMLABS_RUNTIME ]]
+then
+    export PHP_CONFIGURE=" --with-wasm-runtime=${WASMLABS_RUNTIME} ${PHP_CONFIGURE}"
+fi
+
+logStatus "Configuring build with '${PHP_CONFIGURE}'... "
+./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${PHP_CONFIGURE} || exit 1
+
+export MAKE_TARGETS='cgi'
+if [[ "${WASMLABS_RUNTIME}" == "wasmedge" ]]
+then
+    export MAKE_TARGETS="${MAKE_TARGETS} cli"
+fi
+
+logStatus "Building '${MAKE_TARGETS}'... "
+make -j ${MAKE_TARGETS} || exit 1
+
+logStatus "Preparing artifacts... "
+mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
+
+cp sapi/cgi/php-cgi ${WASMLABS_OUTPUT}/bin/php-cgi${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME} || exit 1
+
+if [[ "${WASMLABS_RUNTIME}" == "wasmedge" ]]
+then
+    cp sapi/cli/php ${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME} || exit 1
+fi
+
+logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/php/php-8.2.0/wl-tag.sh
+++ b/php/php-8.2.0/wl-tag.sh
@@ -1,0 +1,1 @@
+export WLR_TAG="php/8.2.0"

--- a/php/php-8.2.0/wl-test.sh
+++ b/php/php-8.2.0/wl-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+if ! [ -x "$(command -v php)" ]
+then
+    echo "Native php is required in PATH on the host to act as orchestrator for php.wasm tests!"
+    exit 1
+fi
+
+if [ -f "${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}" ]
+then
+    export WASMLABS_TESTED_MODULE="${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}"
+else
+    export WASMLABS_TESTED_MODULE="${WASMLABS_OUTPUT}/bin/php-cgi${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}"
+fi
+
+if ! [ -x "${WASMLABS_TESTED_MODULE}" ]
+then
+    echo "WASM module not found at '${WASMLABS_TESTED_MODULE}'"
+    exit 1
+fi
+
+cd "${WASMLABS_CHECKOUT_PATH}"
+echo "Calling 'WASMLABS_TESTED_MODULE=${WASMLABS_TESTED_MODULE} php -f run-tests.php -- -p ${WASMLABS_TEST_RUNTIME_WRAPPER} -j6' to run tests..."
+php -f run-tests.php -- -p ${WASMLABS_TEST_RUNTIME_WRAPPER} -j6 \
+    tests/lang \
+    tests/output \
+    tests/strings \
+    Zend/tests/fibers
+
+# tests/ \
+# ext/standard/tests \


### PR DESCRIPTION
- Port the existing php 7 patches to php-8.1.11 and php-8.2.0
- Fibers are not supported - attempts to use Fiber code will lead to errors.
- WasmEdge (server-side sockets) are only available for php-8.2.0