### PR TITLE
chore: Bump wasi-sdk

### DIFF
--- a/Dockerfile.wasi-builder
+++ b/Dockerfile.wasi-builder
@@ -1,5 +1,5 @@
 FROM ubuntu:latest@sha256:4b1d0c4a2d2aaf63b37111f34eb9fa89fa1bf53dd6e4ca954d47caebca4005c2
-ARG WASI_SDK_VERSION=16
+ARG WASI_SDK_VERSION=19
 ENV WASI_SDK=wasi-sdk-${WASI_SDK_VERSION}
 ENV WASI_SDK_ROOT=/wasi-sdk
 RUN apt update && \

--- a/Makefile.builders
+++ b/Makefile.builders
@@ -1,5 +1,5 @@
 BUILDER_ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-.PHONY: wasi-builder-16
-wasi-builder-16:
-	docker build --build-arg WASI_SDK_VERSION=16 -f ${BUILDER_ROOT_DIR}/Dockerfile.wasi-builder -t ghcr.io/vmware-labs/wasi-builder:16 ${BUILDER_ROOT_DIR}
+.PHONY: wasi-builder-19
+wasi-builder-19:
+	docker build --build-arg WASI_SDK_VERSION=19 -f ${BUILDER_ROOT_DIR}/Dockerfile.wasi-builder -t ghcr.io/vmware-labs/wasi-builder:19 ${BUILDER_ROOT_DIR}

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-ARG WASI_SDK_VERSION=16
+ARG WASI_SDK_VERSION=19
 FROM ghcr.io/vmware-labs/wasi-builder:${WASI_SDK_VERSION}
 RUN DEBIAN_FRONTEND=noninteractive apt install -y \
       bison \

--- a/php/Makefile
+++ b/php/Makefile
@@ -1,11 +1,11 @@
-WASI_SDK_VERSION ?= 16
+WASI_SDK_VERSION ?= 19
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
 include ../Makefile.builders
 
 .PHONY: php-builder
-php-builder: wasi-builder-16
+php-builder: wasi-builder-$(WASI_SDK_VERSION)
 	docker build -f ${ROOT_DIR}/Dockerfile --build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) -t ghcr.io/vmware-labs/php-builder:wasi-$(WASI_SDK_VERSION) ${ROOT_DIR}
 
 .PHONY: php-*

--- a/php/php-7.3.33/patches/0004-Disable-usage-of-mmap-to-fix-correctness-and-stabili.patch
+++ b/php/php-7.3.33/patches/0004-Disable-usage-of-mmap-to-fix-correctness-and-stabili.patch
@@ -239,7 +239,7 @@ index 0000000000..c57f0c8a3a
 +
 +Take a look [here](https://linux.die.net/man/2/mmap) for the docs for mmap and munmap
 +
-+The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-16 tag).
++The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-19 tag).
 +
 + - mmap uses malloc to reserve the necessary amount of memory (always ignoring the addr hint)
 + - mmap zeroes out bytes if MAP_ANONYMOUS is used

--- a/php/php-7.3.33/patches/0005-Remove-build-script-from-patch.patch
+++ b/php/php-7.3.33/patches/0005-Remove-build-script-from-patch.patch
@@ -76,7 +76,7 @@ index c57f0c8a3a..0000000000
 -
 -Take a look [here](https://linux.die.net/man/2/mmap) for the docs for mmap and munmap
 -
--The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-16 tag).
+-The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-19 tag).
 -
 - - mmap uses malloc to reserve the necessary amount of memory (always ignoring the addr hint)
 - - mmap zeroes out bytes if MAP_ANONYMOUS is used

--- a/php/php-7.3.33/wasmlabs-README.md
+++ b/php/php-7.3.33/wasmlabs-README.md
@@ -64,7 +64,7 @@ We are building without MMAP support. To make it work, changes had to be made to
 
 Take a look [here](https://linux.die.net/man/2/mmap) for the docs for mmap and munmap
 
-The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-16 tag).
+The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-19 tag).
 
  - mmap uses malloc to reserve the necessary amount of memory (always ignoring the addr hint)
  - mmap zeroes out bytes if MAP_ANONYMOUS is used

--- a/php/php-7.4.32/patches/0002-Fix-mmap-issues.-Add-readme.patch
+++ b/php/php-7.4.32/patches/0002-Fix-mmap-issues.-Add-readme.patch
@@ -238,7 +238,7 @@ index 00000000..c57f0c8a
 +
 +Take a look [here](https://linux.die.net/man/2/mmap) for the docs for mmap and munmap
 +
-+The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-16 tag).
++The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-19 tag).
 +
 + - mmap uses malloc to reserve the necessary amount of memory (always ignoring the addr hint)
 + - mmap zeroes out bytes if MAP_ANONYMOUS is used

--- a/php/php-7.4.32/patches/0003-Remove-files.patch
+++ b/php/php-7.4.32/patches/0003-Remove-files.patch
@@ -76,7 +76,7 @@ index c57f0c8a..00000000
 -
 -Take a look [here](https://linux.die.net/man/2/mmap) for the docs for mmap and munmap
 -
--The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-16 tag).
+-The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-19 tag).
 -
 - - mmap uses malloc to reserve the necessary amount of memory (always ignoring the addr hint)
 - - mmap zeroes out bytes if MAP_ANONYMOUS is used

--- a/php/php-7.4.32/wasmlabs-README.md
+++ b/php/php-7.4.32/wasmlabs-README.md
@@ -64,7 +64,7 @@ We are building without MMAP support. To make it work, changes had to be made to
 
 Take a look [here](https://linux.die.net/man/2/mmap) for the docs for mmap and munmap
 
-The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-16 tag).
+The mmap support in wasi-libc is just a rudimentary emulation (as of the wasi-sdk-19 tag).
 
  - mmap uses malloc to reserve the necessary amount of memory (always ignoring the addr hint)
  - mmap zeroes out bytes if MAP_ANONYMOUS is used


### PR DESCRIPTION
Note: the branch name is not reflecting the real change, but I don't think it's worth reopening the PR just for that.

Fixes: https://github.com/vmware-labs/webassembly-language-runtimes/issues/23