### PR TITLE
feat: Add scripts that generate a python wasm binary

### DIFF
--- a/libs/uuid/libuuid-1.0.3/wl-build.sh
+++ b/libs/uuid/libuuid-1.0.3/wl-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+cd "${WASMLABS_CHECKOUT_PATH}"
+
+logStatus "Downloading files from singlestore-labs/python-wasi... "
+git clone --depth 1 --branch main --no-checkout https://github.com/singlestore-labs/python-wasi
+cd python-wasi
+git sparse-checkout set docker/include/uuid.h docker/lib/libuuid.a
+git checkout main
+cd ..
+
+logStatus "Preparing artifacts... "
+mkdir -p ${WASMLABS_OUTPUT}/include 2>/dev/null || exit 1
+mkdir -p ${WASMLABS_OUTPUT}/lib 2>/dev/null || exit 1
+
+cp python-wasi/docker/include/uuid.h ${WASMLABS_OUTPUT}/include || exit 1
+cp python-wasi/docker/lib/libuuid.a ${WASMLABS_OUTPUT}/lib || exit 1
+
+logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/libs/uuid/wl-env-repo.sh
+++ b/libs/uuid/wl-env-repo.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ $1 == "--unset" ]]
+then
+    unset WASMLABS_REPO
+    unset WASMLABS_REPO_NAME
+    return
+fi
+
+export WASMLABS_REPO=https://git.code.sf.net/p/libuuid/code
+export WASMLABS_REPO_NAME=uuid
+

--- a/libs/zlib/v1.2.11/wl-build.sh
+++ b/libs/zlib/v1.2.11/wl-build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+cd "${WASMLABS_CHECKOUT_PATH}"
+
+logStatus "Downloading files from singlestore-labs/python-wasi... "
+git clone --depth 1 --branch main --no-checkout https://github.com/singlestore-labs/python-wasi
+cd python-wasi
+git sparse-checkout set docker/include/zconf.h docker/include/zlib.h docker/lib/libz.a
+git checkout main
+cd ..
+
+logStatus "Preparing artifacts... "
+mkdir -p ${WASMLABS_OUTPUT}/include 2>/dev/null || exit 1
+mkdir -p ${WASMLABS_OUTPUT}/lib 2>/dev/null || exit 1
+
+cp python-wasi/docker/include/zlib.h ${WASMLABS_OUTPUT}/include || exit 1
+cp python-wasi/docker/include/zconf.h ${WASMLABS_OUTPUT}/include || exit 1
+cp python-wasi/docker/lib/libz.a ${WASMLABS_OUTPUT}/lib || exit 1
+
+rm -rf python-wasi
+logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/libs/zlib/wl-env-repo.sh
+++ b/libs/zlib/wl-env-repo.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ $1 == "--unset" ]]
+then
+    unset WASMLABS_REPO
+    unset WASMLABS_REPO_NAME
+    return
+fi
+
+export WASMLABS_REPO=https://github.com/madler/zlib
+export WASMLABS_REPO_NAME=zlib
+

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,83 @@
+# About
+
+This folder and its subfolders contain the scripts used to build WASM ports of python versions.
+
+The initially supported version is python 3.11.1.
+
+The build is based on CPython's WASM+WASI support - https://pythondev.readthedocs.io/wasm.html
+
+The initial version depends on pre-build WASM libraries found in https://github.com/singlestore-labs/python-wasi/tree/main/docker for `zlib` or `libuuid`. With time we will build those on our own during the build process.
+
+# Prerequisites
+
+To run this build you will need
+
+ - the following list of build tools
+
+```
+sudo apt install -y autoconf automake build-essential clang git pkg-config wget
+
+```
+ - wasi-sdk from here - https://github.com/WebAssembly/wasi-sdk/releases
+
+
+# Building
+
+You can build Python by running the following:
+
+```
+export WASI_SDK_ROOT=/opt/wasi-sdk
+wl-make.sh python/v3.11.1
+```
+
+# Running python.wasm
+
+The build will provide you with a wasm binary and with a separate zip file that contains all scripts from python's standard library.
+
+```
+build-output/python/
+└── v3.11.1
+    ├── bin
+    │   └── python.wasm
+    ├── include
+    ├── lib
+    └── usr
+        └── local
+            └── lib
+                └── python311.zip
+```
+
+The default PYTHONPATH includes `/usr/local/lib/python311.zip` so when running the binary you will need to ensure that python311.zip is mapped at the proper location in the WASM sandboxed environment. For example
+
+```bash
+# Running in build-output/python/v3.11.1
+
+wasmtime run bin/python.wasm --mapdir /::.
+Python 3.11.1 (tags/v3.11.1:a7a450f, Jan 14 2023, 01:44:50) [Clang 14.0.4 (https://github.com/llvm/llvm-project 29f1039a7285a5c3a9c353d05414 on wasi
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import sys
+>>> import pprint
+>>> pprint.pprint(sys.path)
+['',
+ '/usr/local/lib/python311.zip',
+ '/usr/local/lib/python3.11',
+ '/usr/local/lib/python3.11/lib-dynload']
+>>>
+```
+
+Of course, you could always have that zip file in another folder and provide the PYTHONPATH environment variable to point to it. For example:
+
+```bash
+# Running in build-output/python/v3.11.1
+
+wasmtime run \
+   --env PYTHONPATH=/mypath/python311.zip \
+   --env PYTHONHOME=/mypath/python311.zip \
+   --mapdir=/mypath::usr/local/lib/ bin/python.wasm \
+   -- -c "import sys; import pprint; pprint.pprint(sys.path)"
+['',
+ '/mypath/python311.zip',
+ '/mypath/python311.zip/lib/python311.zip',
+ '/mypath/python311.zip/lib/python3.11',
+ '/mypath/python311.zip/lib/python3.11/lib-dynload']
+```

--- a/python/v3.11.1/wl-build-deps.sh
+++ b/python/v3.11.1/wl-build-deps.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+if [ "${BASH_SOURCE-}" = "$0" ]; then
+    echo "You must source this script to add to CFLAGS and LDFLAGS: \$ source $0" >&2
+    return
+fi
+
+logStatus "Building dependencies... "
+
+### uuid
+$WASMLABS_MAKE ${WASMLABS_REPO_ROOT}/libs/uuid/libuuid-1.0.3 || exit 1
+
+export CFLAGS_DEPENDENCIES="-I${WASMLABS_OUTPUT_BASE}/uuid/libuuid-1.0.3/include ${CFLAGS_DEPENDENCIES}"
+export LDFLAGS_DEPENDENCIES="-L${WASMLABS_OUTPUT_BASE}/uuid/libuuid-1.0.3/lib ${LDFLAGS_DEPENDENCIES}"
+
+
+### zlib
+$WASMLABS_MAKE ${WASMLABS_REPO_ROOT}/libs/zlib/v1.2.11 || exit 1
+
+export CFLAGS_DEPENDENCIES="-I${WASMLABS_OUTPUT_BASE}/zlib/v1.2.11/include ${CFLAGS_DEPENDENCIES}"
+export LDFLAGS_DEPENDENCIES="-L${WASMLABS_OUTPUT_BASE}/zlib/v1.2.11/lib ${LDFLAGS_DEPENDENCIES}"

--- a/python/v3.11.1/wl-build.sh
+++ b/python/v3.11.1/wl-build.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+cd "${WASMLABS_CHECKOUT_PATH}"
+
+# The PREFIX for builder-python MUST be outside of the current build as we need
+# a distclean before building for WASI. The distclean will recursively remove
+# all .so files in the current folder, so if builder-python is installed here
+# it will be botched.
+export BUILDER_PYTHON_PREFIX="${WASMLABS_CHECKOUT_PATH}/../builder-python"
+
+if builder-python/bin/python3.11 -c "import sys; import zipfiles; exit( 0 if sys.path[1].startswith(sys.argv[1]) else 1)" "${BUILDER_PYTHON_PREFIX}"
+then
+    logStatus "Using pre-built builder python (on host) from ${BUILDER_PYTHON_PREFIX}... "
+else
+    logStatus "Building builder python (on host) at ${BUILDER_PYTHON_PREFIX}... "
+    mkdir ${BUILDER_PYTHON_PREFIX}
+    make distclean
+    ${WASMLABS_REPO_ROOT}/scripts/wl-hostbuild.sh ./configure --prefix ${BUILDER_PYTHON_PREFIX} || exit 1
+    make install || exit 1
+    make distclean || exit 1
+fi
+
+# export CFLAGS_CONFIG="-O3 -g"
+export CFLAGS_CONFIG="-O3"
+
+export CFLAGS="${CFLAGS_CONFIG} ${CFLAGS_DEPENDENCIES} ${CFLAGS}"
+export LDFLAGS="${LDFLAGS_DEPENDENCIES} ${LDFLAGS}"
+
+export PYTHON_WASM_CONFIGURE="--with-build-python=${BUILDER_PYTHON_PREFIX}/bin/python3.11"
+
+if [[ -v WASMLABS_RUNTIME ]]
+then
+    export PYTHON_WASM_CONFIGURE=" --with-wasm-runtime=${WASMLABS_RUNTIME} ${PYTHON_WASM_CONFIGURE}"
+fi
+
+logStatus "Configuring build with '${PYTHON_WASM_CONFIGURE}'... "
+CONFIG_SITE=./Tools/wasm/config.site-wasm32-wasi ./configure -C --host=wasm32-wasi --build=$(./config.guess) ${PYTHON_WASM_CONFIGURE} || exit 1
+
+export MAKE_TARGETS='python.wasm wasm_stdlib'
+
+logStatus "Building '${MAKE_TARGETS}'... "
+make -j ${MAKE_TARGETS} || exit 1
+
+logStatus "Preparing artifacts... "
+mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
+mkdir -p ${WASMLABS_OUTPUT}/usr/local/lib 2>/dev/null || exit 1
+
+cp python.wasm ${WASMLABS_OUTPUT}/bin/python${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}.wasm || exit 1
+cp usr/local/lib/python3.11.zip ${WASMLABS_OUTPUT}/usr/local/lib/ || exit 1
+
+logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/python/v3.11.1/wl-tag.sh
+++ b/python/v3.11.1/wl-tag.sh
@@ -1,0 +1,1 @@
+export WLR_TAG="php/7.4.32"

--- a/python/wl-env-repo.sh
+++ b/python/wl-env-repo.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ $1 == "--unset" ]]
+then
+    unset WASMLABS_REPO
+    unset WASMLABS_REPO_NAME
+    return
+fi
+
+export WASMLABS_REPO=https://github.com/python/cpython
+export WASMLABS_REPO_NAME=python
+

--- a/scripts/wl-hostbuild.sh
+++ b/scripts/wl-hostbuild.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+if [[ ! -v WASI_SDK_ROOT ]]
+then
+    echo "Please set WASI_SDK_ROOT and run again"
+    exit 1
+fi
+
+env -u CC -u LD -u CXX -u NM -u AR -u RANLIB $@ || exit 1


### PR DESCRIPTION
This is an initial version that builds python wasm using the CPython build scripts

It leverages the wasm library binaries available in `https://github.com/singlestore-labs/python-wasi/tree/main/docker`

Created issues to fix that subsequently
 - https://github.com/vmware-labs/webassembly-language-runtimes/issues/29
 - https://github.com/vmware-labs/webassembly-language-runtimes/issues/30

Instructions on how to build can be found in [python/README.md](python/README.md)

Note: this does not include gitactions for releasing of the binary. They will be added subsequently.