### PR TITLE
Add Ruby 3.2.0

### DIFF
--- a/Dockerfile.wasi-builder
+++ b/Dockerfile.wasi-builder
@@ -1,7 +1,9 @@
-FROM ubuntu:latest@sha256:4b1d0c4a2d2aaf63b37111f34eb9fa89fa1bf53dd6e4ca954d47caebca4005c2
+ARG WASM_BASE=20220116
+FROM ghcr.io/vmware-labs/wasm-base:${WASM_BASE}
 ARG WASI_SDK_VERSION=19
 ENV WASI_SDK=wasi-sdk-${WASI_SDK_VERSION}
 ENV WASI_SDK_ROOT=/wasi-sdk
+ENV WASI_SDK_PATH=${WASI_SDK_ROOT}
 RUN apt update && \
       DEBIAN_FRONTEND=noninteractive apt install -y \
         autoconf \
@@ -9,8 +11,7 @@ RUN apt update && \
         build-essential \
         clang \
         git \
-        pkg-config \
-        wget
+        pkg-config
 RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/${WASI_SDK}/${WASI_SDK}.0-linux.tar.gz && \
       mkdir /wasi-sdk && \
       tar xf ${WASI_SDK}.0-linux.tar.gz --strip-components=1 -C ${WASI_SDK_ROOT} && \

--- a/Dockerfile.wasm-base
+++ b/Dockerfile.wasm-base
@@ -1,0 +1,9 @@
+FROM ubuntu:20.04
+ARG BINARYEN_VERSION=111
+RUN apt update && \
+    DEBIAN_FRONTEND=noninteractive apt install -y \
+      wget && \
+    wget https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz && \
+    tar -xf binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz --strip-components=1 -C /opt && \
+    rm binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz
+ENV PATH="$PATH:/opt/bin"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ php/php-*:
 php/wasmedge-php-7.4.32:
 	WASMLABS_RUNTIME=wasmedge make -C php $(subst php/wasmedge-php-,php-,$@)
 
+.PHONY: ruby/v*
+ruby/v*:
+	make -C ruby $(subst ruby/,,$@)
+
 .PHONY: clean
 clean:
 	make -C php clean

--- a/Makefile.builders
+++ b/Makefile.builders
@@ -1,5 +1,9 @@
 BUILDER_ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
+.PHONY: wasm-base
+wasm-base:
+	docker build --build-arg BINARYEN_VERSION=111 -f ${BUILDER_ROOT_DIR}/Dockerfile.wasm-base -t ghcr.io/vmware-labs/wasm-base:20220116 ${BUILDER_ROOT_DIR}
+
 .PHONY: wasi-builder-19
-wasi-builder-19:
+wasi-builder-19: wasm-base
 	docker build --build-arg WASI_SDK_VERSION=19 -f ${BUILDER_ROOT_DIR}/Dockerfile.wasi-builder -t ghcr.io/vmware-labs/wasi-builder:19 ${BUILDER_ROOT_DIR}

--- a/ruby/.dockerignore
+++ b/ruby/.dockerignore
@@ -1,0 +1,2 @@
+build-output
+build-staging

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,0 +1,7 @@
+ARG WASI_SDK_VERSION=19
+FROM ghcr.io/vmware-labs/wasi-builder:${WASI_SDK_VERSION}
+RUN DEBIAN_FRONTEND=noninteractive apt install -y \
+      ruby \
+      bison \
+      gperf
+ADD . /wlr/ruby

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,0 +1,18 @@
+WASI_SDK_VERSION ?= 19
+
+ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
+include ../Makefile.builders
+
+.PHONY: ruby-builder
+ruby-builder: wasi-builder-$(WASI_SDK_VERSION)
+	docker build -f ${ROOT_DIR}/Dockerfile --build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) -t ghcr.io/vmware-labs/ruby-builder:wasi-$(WASI_SDK_VERSION) ${ROOT_DIR}
+
+.PHONY: v*
+v*: ruby-builder
+	mkdir -p build-output build-staging
+	docker run --rm -e WASMLABS_RUNTIME -e WASMLABS_TAG=v3_2_0 -v ${ROOT_DIR}/build-output:/wlr/build-output -v ${ROOT_DIR}/build-staging:/wlr/build-staging ghcr.io/vmware-labs/ruby-builder:wasi-${WASI_SDK_VERSION} ./wl-make.sh ruby/$@
+
+.PHONY: clean
+clean:
+	rm -rf build-output build-staging

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,15 @@
+# About
+
+## Building
+
+You can build Ruby by running the following Makefile targets:
+
+- `make v3_2_0`
+
+## Running a script with ruby
+
+Don't forget to map the folder that contains the ruby script, which you want to run. For example:
+
+```bash
+wasmtime --mapdir=./::./ -- ruby my-script.rb
+```

--- a/ruby/v3_2_0/wl-build.sh
+++ b/ruby/v3_2_0/wl-build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [[ ! -v WASMLABS_ENV ]]
+then
+    echo "Wasmlabs environment is not set"
+    exit 1
+fi
+
+cd "${WASMLABS_CHECKOUT_PATH}"
+
+mkdir build
+
+ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
+
+./autogen.sh
+
+./configure \
+    --host wasm32-unknown-wasi \
+    --with-ext=ripper,monitor \
+    --with-static-linked-ext \
+    LDFLAGS=" \
+      -Xlinker --stack-first \
+      -Xlinker -z -Xlinker stack-size=16777216 \
+    " \
+    optflags="-O2" \
+    debugflags="" \
+    wasmoptflags="-O2"
+
+make ruby
+
+cp ruby ${WASMLABS_OUTPUT}/bin/ || exit 1
+
+logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/ruby/v3_2_0/wl-tag.sh
+++ b/ruby/v3_2_0/wl-tag.sh
@@ -1,0 +1,1 @@
+export WLR_TAG="ruby/3.2.0"

--- a/ruby/wl-env-repo.sh
+++ b/ruby/wl-env-repo.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ $1 == "--unset" ]]
+then
+    unset WASMLABS_REPO
+    unset WASMLABS_REPO_NAME
+    return
+fi
+
+export WASMLABS_REPO=https://github.com/ruby/ruby.git
+export WASMLABS_REPO_NAME=ruby


### PR DESCRIPTION
As part of this work, introduce the concept of a wasm-base base image that contains common tooling for handling WebAssembly common artifacts.

This base image contains Binaryen as of now, so that we can run `wasm-opt` on the resulting binaries, for example, to run the Asyncify pass on certain resulting artifacts.