### PR TITLE
Add Ruby GH workflows

### DIFF
--- a/.github/workflows/build-php.yaml
+++ b/.github/workflows/build-php.yaml
@@ -47,12 +47,12 @@ jobs:
       - name: Rename artifacts
         shell: bash
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}.wasm}
+          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}}.wasm
       - name: Rename artifacts
         shell: bash
         if: ${{ matrix.build-php-cli }}
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}.wasm}
+          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}}.wasm
       - name: Upload php-${{ matrix.version }}${{ matrix.suffix }}.wasm artifact
         uses: actions/upload-artifact@v3
         if: ${{ matrix.build-php-cli }}

--- a/.github/workflows/build-ruby.yaml
+++ b/.github/workflows/build-ruby.yaml
@@ -1,0 +1,32 @@
+name: Build Ruby
+on:
+  push:
+    # By specifying branches explicitly, we avoid this workflow from
+    # running on tag push. We have a dedicated workflow to be ran when
+    # a tag is pushed.
+    branches:
+      - "*"
+  pull_request:
+jobs:
+  build-ruby:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: 3.2.0
+            target_version: 3_2_0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Build Ruby
+        run: make ruby/v${{ matrix.target_version }}
+      - name: Rename artifacts
+        shell: bash
+        run: |
+          sudo mv ruby/build-output/ruby/v${{ matrix.target_version }}/bin/ruby{,-${{ matrix.version }}}.wasm
+      - name: Upload ruby-${{ matrix.version }}.wasm artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ruby-${{ matrix.version }}.wasm
+          path: ruby/build-output/ruby/v${{ matrix.target_version }}/bin/ruby-${{ matrix.version }}.wasm

--- a/.github/workflows/release-php.yaml
+++ b/.github/workflows/release-php.yaml
@@ -40,8 +40,6 @@ jobs:
             build-php-cli: false
             version: 8.2.0
     runs-on: ubuntu-latest
-    env:
-      BINARYEN_VERSION: 111
     steps:
       - name: Checkout repository
         # Only run for the PHP version specified in the git tag.
@@ -65,7 +63,7 @@ jobs:
         if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         shell: bash
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}.wasm}
+          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}}.wasm
       - name: Rename release artifacts
         # Only run for the PHP version specified in the git tag.
         #
@@ -74,38 +72,7 @@ jobs:
         if: ${{ startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version)) && matrix.build-php-cli }}
         shell: bash
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}.wasm}
-      - name: Setup binaryen
-        # Only run for the PHP version specified in the git tag.
-        #
-        # This if could be moved to the parent `job` section when it's
-        # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
-        shell: bash
-        run: |
-          wget https://github.com/WebAssembly/binaryen/releases/download/version_${{ env.BINARYEN_VERSION }}/binaryen-version_${{ env.BINARYEN_VERSION }}-x86_64-linux.tar.gz
-          tar -xf binaryen-version_${{ env.BINARYEN_VERSION }}-x86_64-linux.tar.gz --strip-components=1 -C /opt
-          rm binaryen-version_${{ env.BINARYEN_VERSION }}-x86_64-linux.tar.gz
-      - name: Optimize php-cgi release artifacts
-        # Only run for the PHP version specified in the git tag.
-        #
-        # This if could be moved to the parent `job` section when it's
-        # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
-        shell: bash
-        run: |
-          sudo /opt/bin/wasm-opt -Os -o php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.size-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm
-          sudo /opt/bin/wasm-opt -O -o php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.speed-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm
-      - name: Optimize php release artifacts
-        # Only run for the PHP version specified in the git tag.
-        #
-        # This if could be moved to the parent `job` section when it's
-        # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: ${{ startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version)) && matrix.build-php-cli }}
-        shell: bash
-        run: |
-          sudo /opt/bin/wasm-opt -Os -o php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.size-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.wasm
-          sudo /opt/bin/wasm-opt -O -o php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.speed-optimized.wasm php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.wasm
+          sudo mv php/build-output/php/php-${{ matrix.version }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}}.wasm
       - name: Create release
         # Only run for the PHP version specified in the git tag.
         #
@@ -116,7 +83,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create --generate-notes ${{ github.ref_name }} || true
-      - name: Append php-cgi release assets
+      - name: Append PHP release assets
         # Only run for the PHP version specified in the git tag.
         #
         # This if could be moved to the parent `job` section when it's
@@ -126,22 +93,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm \
-            php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.size-optimized.wasm \
-            php/build-output/php/php-${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.speed-optimized.wasm
-      - name: Append php release assets
-        # Only run for the PHP version specified in the git tag.
-        #
-        # This if could be moved to the parent `job` section when it's
-        # supported by GitHub (https://github.com/community/community/discussions/37883)
-        if: ${{ startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version)) && matrix.build-php-cli }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ github.ref_name }} \
-            php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.wasm \
-            php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.size-optimized.wasm \
-            php/build-output/php/php-${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.speed-optimized.wasm
+            php/build-output/php/php-${{ matrix.version }}/bin/*.wasm
       - name: Generate release assets digests
         # Only run for the PHP version specified in the git tag.
         #

--- a/.github/workflows/release-ruby.yaml
+++ b/.github/workflows/release-ruby.yaml
@@ -1,0 +1,87 @@
+# Note that for this workflow to be triggered, the tag needs to be
+# created of the form `ruby/<version>+<buildinfo>`, where <buildinfo>
+# by convention is YYYYMMDD-<short-sha> (short SHA can be calculated
+# with `git rev-parse --short HEAD`). An example of a tag following
+# the convention that triggers automation would be
+# `ruby/3.2.0+20221123-8dfe8b9`.
+name: Release Ruby
+on:
+  push:
+    tags:
+      - ruby/*
+jobs:
+  release-ruby:
+    strategy:
+      matrix:
+        include:
+          - version: 3.2.0
+            target_version: 3_2_0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        # Only run for the Ruby version specified in the git tag.
+        #
+        # This if could be moved to the parent `job` section when it's
+        # supported by GitHub (https://github.com/community/community/discussions/37883)
+        if: startsWith(github.event.ref,  format('refs/tags/ruby/{0}+', matrix.version))
+        uses: actions/checkout@v3
+      - name: Build Ruby
+        # Only run for the Ruby version specified in the git tag.
+        #
+        # This if could be moved to the parent `job` section when it's
+        # supported by GitHub (https://github.com/community/community/discussions/37883)
+        if: startsWith(github.event.ref, format('refs/tags/ruby/{0}+', matrix.version))
+        run: make ruby/v${{ matrix.target_version }}
+      - name: Rename release artifacts
+        # Only run for the Ruby version specified in the git tag.
+        #
+        # This if could be moved to the parent `job` section when it's
+        # supported by GitHub (https://github.com/community/community/discussions/37883)
+        if: startsWith(github.event.ref, format('refs/tags/ruby/{0}+', matrix.version))
+        shell: bash
+        run: |
+          sudo mv ruby/build-output/ruby/v${{ matrix.target_version }}/bin/ruby{,-${{ matrix.version }}}.wasm
+      - name: Create release
+        # Only run for the Ruby version specified in the git tag.
+        #
+        # This if could be moved to the parent `job` section when it's
+        # supported by GitHub (https://github.com/community/community/discussions/37883)
+        if: startsWith(github.event.ref, format('refs/tags/ruby/{0}+', matrix.version))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create --generate-notes ${{ github.ref_name }} || true
+      - name: Append Ruby release assets
+        # Only run for the Ruby version specified in the git tag.
+        #
+        # This if could be moved to the parent `job` section when it's
+        # supported by GitHub (https://github.com/community/community/discussions/37883)
+        if: ${{ startsWith(github.event.ref, format('refs/tags/ruby/{0}+', matrix.version))}}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} \
+            ruby/build-output/ruby/v${{ matrix.target_version }}/bin/*.wasm
+      - name: Generate release assets digests
+        # Only run for the Ruby version specified in the git tag.
+        #
+        # This if could be moved to the parent `job` section when it's
+        # supported by GitHub (https://github.com/community/community/discussions/37883)
+        if: ${{ startsWith(github.event.ref, format('refs/tags/ruby/{0}+', matrix.version))}}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for asset in ruby/build-output/ruby/v${{ matrix.target_version }}/bin/*.wasm; do
+            sha256sum "$asset" | sudo tee "$asset.sha256sum" > /dev/null
+          done
+      - name: Append release assets digests
+        # Only run for the Ruby version specified in the git tag.
+        #
+        # This if could be moved to the parent `job` section when it's
+        # supported by GitHub (https://github.com/community/community/discussions/37883)
+        if: ${{ startsWith(github.event.ref, format('refs/tags/ruby/{0}+', matrix.version))}}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} \
+            ruby/build-output/ruby/v${{ matrix.target_version }}/bin/*.sha256sum

--- a/php/php-7.3.33/wl-build.sh
+++ b/php/php-7.3.33/wl-build.sh
@@ -36,6 +36,7 @@ make cgi || exit 1
 logStatus "Preparing artifacts... "
 mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
 
+logStatus "Running wasm-opt with the asyncify pass on php-cgi..."
 wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php-cgi.wasm sapi/cgi/php-cgi || exit 1
 
 logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/php/php-7.3.33/wl-build.sh
+++ b/php/php-7.3.33/wl-build.sh
@@ -36,6 +36,6 @@ make cgi || exit 1
 logStatus "Preparing artifacts... "
 mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
 
-cp sapi/cgi/php-cgi ${WASMLABS_OUTPUT}/bin/ || exit 1
+wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php-cgi.wasm sapi/cgi/php-cgi || exit 1
 
 logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/php/php-7.4.32/wl-build.sh
+++ b/php/php-7.4.32/wl-build.sh
@@ -48,10 +48,12 @@ make -j ${MAKE_TARGETS} || exit 1
 logStatus "Preparing artifacts... "
 mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
 
+logStatus "Running wasm-opt with the asyncify pass on php-cgi..."
 wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php-cgi${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}.wasm sapi/cgi/php-cgi || exit 1
 
 if [[ "${WASMLABS_RUNTIME}" == "wasmedge" ]]
 then
+    logStatus "Running wasm-opt with the asyncify pass on php.."
     wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}.wasm sapi/cli/php || exit 1
 fi
 

--- a/php/php-7.4.32/wl-build.sh
+++ b/php/php-7.4.32/wl-build.sh
@@ -48,11 +48,11 @@ make -j ${MAKE_TARGETS} || exit 1
 logStatus "Preparing artifacts... "
 mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
 
-cp sapi/cgi/php-cgi ${WASMLABS_OUTPUT}/bin/php-cgi${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME} || exit 1
+wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php-cgi${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}.wasm sapi/cgi/php-cgi || exit 1
 
 if [[ "${WASMLABS_RUNTIME}" == "wasmedge" ]]
 then
-    cp sapi/cli/php ${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME} || exit 1
+    wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}.wasm sapi/cli/php || exit 1
 fi
 
 logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/php/php-8.1.11/wl-build.sh
+++ b/php/php-8.1.11/wl-build.sh
@@ -40,6 +40,7 @@ make cgi  || exit 1
 logStatus "Preparing artifacts... "
 mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
 
+logStatus "Running wasm-opt with the asyncify pass on php-cgi.."
 wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php-cgi.wasm sapi/cgi/php-cgi || exit 1
 
 logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/php/php-8.1.11/wl-build.sh
+++ b/php/php-8.1.11/wl-build.sh
@@ -40,6 +40,6 @@ make cgi  || exit 1
 logStatus "Preparing artifacts... "
 mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
 
-cp sapi/cgi/php-cgi ${WASMLABS_OUTPUT}/bin/ || exit 1
+wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php-cgi.wasm sapi/cgi/php-cgi || exit 1
 
 logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/php/php-8.2.0/wl-build.sh
+++ b/php/php-8.2.0/wl-build.sh
@@ -51,10 +51,12 @@ make -j ${MAKE_TARGETS} || exit 1
 logStatus "Preparing artifacts... "
 mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
 
+logStatus "Running wasm-opt with the asyncify pass on php-cgi.."
 wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php-cgi${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}.wasm sapi/cgi/php-cgi || exit 1
 
 if [[ "${WASMLABS_RUNTIME}" == "wasmedge" ]]
 then
+    logStatus "Running wasm-opt with the asyncify pass on php.."
     wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}.wasm sapi/cli/php || exit 1
 fi
 

--- a/php/php-8.2.0/wl-build.sh
+++ b/php/php-8.2.0/wl-build.sh
@@ -51,11 +51,11 @@ make -j ${MAKE_TARGETS} || exit 1
 logStatus "Preparing artifacts... "
 mkdir -p ${WASMLABS_OUTPUT}/bin 2>/dev/null || exit 1
 
-cp sapi/cgi/php-cgi ${WASMLABS_OUTPUT}/bin/php-cgi${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME} || exit 1
+wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php-cgi${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}.wasm sapi/cgi/php-cgi || exit 1
 
 if [[ "${WASMLABS_RUNTIME}" == "wasmedge" ]]
 then
-    cp sapi/cli/php ${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME} || exit 1
+    wasm-opt -O2 --asyncify --pass-arg=asyncify-ignore-imports -o ${WASMLABS_OUTPUT}/bin/php${WASMLABS_RUNTIME:+-$WASMLABS_RUNTIME}.wasm sapi/cli/php || exit 1
 fi
 
 logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/ruby/v3_2_0/wl-build.sh
+++ b/ruby/v3_2_0/wl-build.sh
@@ -28,6 +28,6 @@ ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
 
 make ruby
 
-cp ruby ${WASMLABS_OUTPUT}/bin/ || exit 1
+mv ruby ${WASMLABS_OUTPUT}/bin/ruby.wasm || exit 1
 
 logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"

--- a/ruby/v3_2_0/wl-build.sh
+++ b/ruby/v3_2_0/wl-build.sh
@@ -10,9 +10,15 @@ cd "${WASMLABS_CHECKOUT_PATH}"
 
 mkdir build
 
+logStatus "Downloading autotools data... "
+
 ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
 
+logStatus "Generating configure script... "
+
 ./autogen.sh
+
+logStatus "Configuring ruby..."
 
 ./configure \
     --host wasm32-unknown-wasi \
@@ -26,8 +32,10 @@ ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
     debugflags="" \
     wasmoptflags="-O2"
 
+logStatus "Building ruby..."
 make ruby
 
+logStatus "Preparing artifacts... "
 mv ruby ${WASMLABS_OUTPUT}/bin/ruby.wasm || exit 1
 
 logStatus "DONE. Artifacts in ${WASMLABS_OUTPUT}"


### PR DESCRIPTION
Fixes: https://github.com/vmware-labs/webassembly-language-runtimes/issues/12

Besides adding the GH workflows to build and release Ruby, this PR also improves the PHP pipelines so that the Asyncify pass happens on the local developer machine, instead of on a GitHub workflow.