### PR TITLE
feature: Allow to skip the configure step

### DIFF
--- a/Dockerfile.wasi-builder
+++ b/Dockerfile.wasi-builder
@@ -1,5 +1,5 @@
 ARG WASM_BASE
-FROM wasm-base:${WASM_BASE}
+FROM ghcr.io/vmware-labs/wasmlabs/wasm-base:${WASM_BASE}
 ARG WASI_SDK_VERSION
 ENV WASI_SDK=wasi-sdk-${WASI_SDK_VERSION}
 ENV WASI_SDK_ROOT=/wasi-sdk

--- a/Dockerfile.wasm-base
+++ b/Dockerfile.wasm-base
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 ARG BINARYEN_VERSION
 ENV BINARYEN_PATH=/opt
 RUN apt update && \

--- a/Makefile.builders
+++ b/Makefile.builders
@@ -4,12 +4,12 @@ WASM_BASE_TAG ?= $(shell git rev-parse --short HEAD)
 
 .PHONY: wasm-base
 wasm-base:
-	docker build --platform linux/amd64 --build-arg BINARYEN_VERSION=111 -f ${BUILDER_ROOT_DIR}/Dockerfile.wasm-base -t wasm-base:$(WASM_BASE_TAG) ${BUILDER_ROOT_DIR}
+	docker build --platform linux/amd64 --build-arg BINARYEN_VERSION=111 -f ${BUILDER_ROOT_DIR}/Dockerfile.wasm-base -t ghcr.io/vmware-labs/wasmlabs/wasm-base:$(WASM_BASE_TAG) ${BUILDER_ROOT_DIR}
 
 .PHONY: wasi-builder-19
 wasi-builder-19: wasm-base
-	docker build --platform linux/amd64 --build-arg WASM_BASE=$(WASM_BASE_TAG) --build-arg WASI_SDK_VERSION=19 -f ${BUILDER_ROOT_DIR}/Dockerfile.wasi-builder -t wasi-builder:19 ${BUILDER_ROOT_DIR}
+	docker build --platform linux/amd64 --build-arg WASM_BASE=$(WASM_BASE_TAG) --build-arg WASI_SDK_VERSION=19 -f ${BUILDER_ROOT_DIR}/Dockerfile.wasi-builder -t ghcr.io/vmware-labs/wasmlabs/wasi-builder:19 ${BUILDER_ROOT_DIR}
 
 .PHONY: wasi-builder-16
 wasi-builder-16: wasm-base
-	docker build --platform linux/amd64 --build-arg WASM_BASE=$(WASM_BASE_TAG) --build-arg WASI_SDK_VERSION=16 -f ${BUILDER_ROOT_DIR}/Dockerfile.wasi-builder -t wasi-builder:16 ${BUILDER_ROOT_DIR}
+	docker build --platform linux/amd64 --build-arg WASM_BASE=$(WASM_BASE_TAG) --build-arg WASI_SDK_VERSION=16 -f ${BUILDER_ROOT_DIR}/Dockerfile.wasi-builder -t ghcr.io/vmware-labs/wasmlabs/wasi-builder:16 ${BUILDER_ROOT_DIR}

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ git add php/php-7.3.33
 git commit -m "Add support to build php version 7.3.33"
 ```
 
-## Performing a release
+## Releasing
 
-In order to perform a release, you first have to tag the project you want to release. You can create a tag by using the `scripts/wl-tag.sh` script.
+In order to release a new version, you first have to tag the project you want to release. You can create a tag by using the `scripts/wl-tag.sh` script.
 
 This script accepts the path to be released, and will create a local tag of the form `<project>/<version>+YYYYMMDD-<short-sha>`. All parameters will be automatically filled by the script, so in order to create a valid tag for PHP 7.3.33, for example, you only have to execute:
 

--- a/libs/sqlite/version-3.39.2/wl-build.sh
+++ b/libs/sqlite/version-3.39.2/wl-build.sh
@@ -16,8 +16,6 @@ export CFLAGS_SQLITE='-DSQLITE_OMIT_WAL=1 -DSQLITE_DEFAULT_SYNCHRONOUS=0 -DSQLIT
 
 logStatus "Using SQLITE DEFINES: ${CFLAGS_SQLITE}"
 
-export SQLITE_CONFIGURE=' --disable-threadsafe --enable-tempstore=yes'
-
 export CFLAGS_BUILD='-D_POSIX_SOURCE=1 -D_GNU_SOURCE=1 -DHAVE_FORK=0 -DWASM_WASI'
 
 # We need to add LDFLAGS ot CFLAGS because autoconf compiles(+links) to binary when checking stuff
@@ -26,8 +24,13 @@ export LDFLAGS="${LDFLAGS_WASI}"
 
 cd "${WASMLABS_CHECKOUT_PATH}"
 
-logStatus "Configuring build with '${SQLITE_CONFIGURE}'... "
-./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${SQLITE_CONFIGURE} || exit 1
+if [[ -z "$WASMLABS_SKIP_CONFIGURE" ]]; then
+    export SQLITE_CONFIGURE=' --disable-threadsafe --enable-tempstore=yes'
+    logStatus "Configuring build with '${SQLITE_CONFIGURE}'... "
+    ./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${SQLITE_CONFIGURE} || exit 1
+else
+    logStatus "Skipping configure..."
+fi
 
 logStatus "Building... "
 make libsqlite3.la || exit 1

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,5 +1,5 @@
 ARG WASI_SDK_VERSION
-FROM wasi-builder:${WASI_SDK_VERSION}
+FROM ghcr.io/vmware-labs/wasmlabs/wasi-builder:${WASI_SDK_VERSION}
 RUN DEBIAN_FRONTEND=noninteractive apt install -y \
       bison \
       re2c \

--- a/php/Makefile
+++ b/php/Makefile
@@ -6,12 +6,12 @@ include ../Makefile.builders
 
 .PHONY: php-builder
 php-builder: wasi-builder-$(WASI_SDK_VERSION)
-	docker build --platform linux/amd64 -f ${ROOT_DIR}/Dockerfile --build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) -t php-builder:wasi-$(WASI_SDK_VERSION) ${ROOT_DIR}
+	docker build --platform linux/amd64 -f ${ROOT_DIR}/Dockerfile --build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) -t ghcr.io/vmware-labs/wasmlabs/php-builder:wasi-$(WASI_SDK_VERSION) ${ROOT_DIR}
 
 .PHONY: php-*
 php-*: php-builder
 	mkdir -p build-output build-staging
-	docker run --platform linux/amd64 --rm -e WASMLABS_RUNTIME -v ${ROOT_DIR}/build-output:/wlr/build-output -v ${ROOT_DIR}/build-staging:/wlr/build-staging php-builder:wasi-${WASI_SDK_VERSION} ./wl-make.sh php/$@
+	docker run --platform linux/amd64 --rm -e WASMLABS_RUNTIME -v ${ROOT_DIR}/build-output:/wlr/build-output -v ${ROOT_DIR}/build-staging:/wlr/build-staging ghcr.io/vmware-labs/wasmlabs/php-builder:wasi-${WASI_SDK_VERSION} ./wl-make.sh php/$@
 
 .PHONY: clean
 clean:

--- a/php/php-7.3.33/wl-build.sh
+++ b/php/php-7.3.33/wl-build.sh
@@ -22,13 +22,17 @@ export LDFLAGS="${LDFLAGS_WASI}"
 
 cd "${WASMLABS_CHECKOUT_PATH}"
 
-logStatus "Generating configure script... "
-./buildconf --force
+if [[ -z "$WASMLABS_SKIP_CONFIGURE" ]]; then
+    logStatus "Generating configure script... "
+    ./buildconf --force
 
-export PHP_CONFIGURE=' --disable-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite'
+    export PHP_CONFIGURE=' --disable-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite'
 
-logStatus "Configuring build with '${PHP_CONFIGURE}'... "
-./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${PHP_CONFIGURE} || exit 1
+    logStatus "Configuring build with '${PHP_CONFIGURE}'... "
+    ./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${PHP_CONFIGURE} || exit 1
+else
+    logStatus "Skipping configure..."
+fi
 
 logStatus "Building php-cgi... "
 # By exporting WASMLABS_SKIP_WASM_OPT envvar during the build, the

--- a/php/php-7.4.32/wl-build.sh
+++ b/php/php-7.4.32/wl-build.sh
@@ -23,18 +23,22 @@ export CFLAGS="${CFS} ${CFLAGS_CONFIG} ${CFLAGS_WASI} ${CFLAGS_SQLITE} ${CFLAGS_
 
 cd "${WASMLABS_CHECKOUT_PATH}"
 
-logStatus "Generating configure script... "
-./buildconf --force || exit 1
+if [[ -z "$WASMLABS_SKIP_CONFIGURE" ]]; then
+    logStatus "Generating configure script... "
+    ./buildconf --force
 
-export PHP_CONFIGURE='--without-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite'
+    export PHP_CONFIGURE='--without-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite'
 
-if [[ -v WASMLABS_RUNTIME ]]
-then
-    export PHP_CONFIGURE=" --with-wasm-runtime=${WASMLABS_RUNTIME} ${PHP_CONFIGURE}"
+    if [[ -v WASMLABS_RUNTIME ]]
+    then
+        export PHP_CONFIGURE=" --with-wasm-runtime=${WASMLABS_RUNTIME} ${PHP_CONFIGURE}"
+    fi
+
+    logStatus "Configuring build with '${PHP_CONFIGURE}'... "
+    ./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${PHP_CONFIGURE} || exit 1
+else
+    logStatus "Skipping configure..."
 fi
-
-logStatus "Configuring build with '${PHP_CONFIGURE}'... "
-./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${PHP_CONFIGURE} || exit 1
 
 export MAKE_TARGETS='cgi'
 if [[ "${WASMLABS_RUNTIME}" == "wasmedge" ]]

--- a/php/php-8.1.11/wl-build.sh
+++ b/php/php-8.1.11/wl-build.sh
@@ -26,13 +26,17 @@ export CFLAGS="${CFLAGS_CONFIG} ${CFLAGS_WASI} ${CFLAGS_SQLITE} ${CFLAGS_DEPENDE
 
 cd "${WASMLABS_CHECKOUT_PATH}"
 
-logStatus "Generating configure script... "
-./buildconf --force || exit 1
+if [[ -z "$WASMLABS_SKIP_CONFIGURE" ]]; then
+    logStatus "Generating configure script... "
+    ./buildconf --force
 
-export PHP_CONFIGURE=' --without-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite --disable-fiber-asm'
+    export PHP_CONFIGURE=' --without-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite --disable-fiber-asm'
 
-logStatus "Configuring build with '${PHP_CONFIGURE}'... "
-./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${PHP_CONFIGURE} || exit 1
+    logStatus "Configuring build with '${PHP_CONFIGURE}'... "
+    ./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${PHP_CONFIGURE} || exit 1
+else
+    logStatus "Skipping configure..."
+fi
 
 logStatus "Building php-cgi... "
 # By exporting WASMLABS_SKIP_WASM_OPT envvar during the build, the

--- a/php/php-8.2.0/wl-build.sh
+++ b/php/php-8.2.0/wl-build.sh
@@ -26,18 +26,22 @@ export CFLAGS="${CFLAGS_CONFIG} ${CFLAGS_WASI} ${CFLAGS_SQLITE} ${CFLAGS_DEPENDE
 
 cd "${WASMLABS_CHECKOUT_PATH}"
 
-logStatus "Generating configure script... "
-./buildconf --force || exit 1
+if [[ -z "$WASMLABS_SKIP_CONFIGURE" ]]; then
+    logStatus "Generating configure script... "
+    ./buildconf --force || exit 1
 
-export PHP_CONFIGURE=' --without-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite --disable-fiber-asm'
+    export PHP_CONFIGURE=' --without-libxml --disable-dom --without-iconv --without-openssl --disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear --disable-phar --disable-opcache --disable-zend-signals --without-pcre-jit --with-sqlite3 --enable-pdo --with-pdo-sqlite --disable-fiber-asm'
 
-if [[ -v WASMLABS_RUNTIME ]]
-then
-    export PHP_CONFIGURE=" --with-wasm-runtime=${WASMLABS_RUNTIME} ${PHP_CONFIGURE}"
+    if [[ -v WASMLABS_RUNTIME ]]
+    then
+        export PHP_CONFIGURE=" --with-wasm-runtime=${WASMLABS_RUNTIME} ${PHP_CONFIGURE}"
+    fi
+
+    logStatus "Configuring build with '${PHP_CONFIGURE}'... "
+    ./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${PHP_CONFIGURE} || exit 1
+else
+    logStatus "Skipping configure..."
 fi
-
-logStatus "Configuring build with '${PHP_CONFIGURE}'... "
-./configure --host=wasm32-wasi host_alias=wasm32-musl-wasi --target=wasm32-wasi target_alias=wasm32-musl-wasi ${PHP_CONFIGURE} || exit 1
 
 export MAKE_TARGETS='cgi'
 if [[ "${WASMLABS_RUNTIME}" == "wasmedge" ]]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,5 @@
 ARG WASI_SDK_VERSION
-FROM wasi-builder:${WASI_SDK_VERSION}
+FROM ghcr.io/vmware-labs/wasmlabs/wasi-builder:${WASI_SDK_VERSION}
 
 # If more capabilities are required from the build-erpython, consult this
 # github workflow configuration for a list of possible dependencies -

--- a/python/Makefile
+++ b/python/Makefile
@@ -7,12 +7,12 @@ include ../Makefile.builders
 
 .PHONY: python-builder
 python-builder: wasi-builder-$(WASI_SDK_VERSION)
-	docker build --platform linux/amd64 -f ${ROOT_DIR}/Dockerfile --build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) -t python-builder:wasi-$(WASI_SDK_VERSION) ${ROOT_DIR}
+	docker build --platform linux/amd64 -f ${ROOT_DIR}/Dockerfile --build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) -t ghcr.io/vmware-labs/wasmlabs/python-builder:wasi-$(WASI_SDK_VERSION) ${ROOT_DIR}
 
 .PHONY: v*
 v*: python-builder
 	mkdir -p build-output build-staging
-	docker run --platform linux/amd64 --rm -e WASMLABS_RUNTIME -v ${ROOT_DIR}/build-output:/wlr/build-output -v ${ROOT_DIR}/build-staging:/wlr/build-staging python-builder:wasi-${WASI_SDK_VERSION} ./wl-make.sh python/$@
+	docker run --platform linux/amd64 --rm -e WASMLABS_RUNTIME -v ${ROOT_DIR}/build-output:/wlr/build-output -v ${ROOT_DIR}/build-staging:/wlr/build-staging ghcr.io/vmware-labs/wasmlabs/python-builder:wasi-${WASI_SDK_VERSION} ./wl-make.sh python/$@
 
 .PHONY: clean
 clean:

--- a/python/v3.11.1/wl-build.sh
+++ b/python/v3.11.1/wl-build.sh
@@ -47,8 +47,12 @@ fi
 # the artifacts have been built.
 export WASMLABS_SKIP_WASM_OPT=1
 
-logStatus "Configuring build with '${PYTHON_WASM_CONFIGURE}'... "
-CONFIG_SITE=./Tools/wasm/config.site-wasm32-wasi ./configure -C --host=wasm32-wasi --build=$(./config.guess) ${PYTHON_WASM_CONFIGURE} || exit 1
+if [[ -z "$WASMLABS_SKIP_CONFIGURE" ]]; then
+    logStatus "Configuring build with '${PYTHON_WASM_CONFIGURE}'... "
+    CONFIG_SITE=./Tools/wasm/config.site-wasm32-wasi ./configure -C --host=wasm32-wasi --build=$(./config.guess) ${PYTHON_WASM_CONFIGURE} || exit 1
+else
+    logStatus "Skipping configure..."
+fi
 
 export MAKE_TARGETS='python.wasm wasm_stdlib'
 

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,5 +1,5 @@
 ARG WASI_SDK_VERSION
-FROM wasi-builder:${WASI_SDK_VERSION}
+FROM ghcr.io/vmware-labs/wasmlabs/wasi-builder:${WASI_SDK_VERSION}
 RUN DEBIAN_FRONTEND=noninteractive apt install -y \
       ruby \
       bison \

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -6,12 +6,12 @@ include ../Makefile.builders
 
 .PHONY: ruby-builder
 ruby-builder: wasi-builder-$(WASI_SDK_VERSION)
-	docker build --platform linux/amd64 -f ${ROOT_DIR}/Dockerfile --build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) -t ruby-builder:wasi-$(WASI_SDK_VERSION) ${ROOT_DIR}
+	docker build --platform linux/amd64 -f ${ROOT_DIR}/Dockerfile --build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) -t ghcr.io/vmware-labs/wasmlabs/ruby-builder:wasi-$(WASI_SDK_VERSION) ${ROOT_DIR}
 
 .PHONY: v*
 v*: ruby-builder
 	mkdir -p build-output build-staging
-	docker run --platform linux/amd64 --rm -e WASMLABS_RUNTIME -e WASMLABS_TAG=v3_2_0 -v ${ROOT_DIR}/build-output:/wlr/build-output -v ${ROOT_DIR}/build-staging:/wlr/build-staging ruby-builder:wasi-${WASI_SDK_VERSION} ./wl-make.sh ruby/$@
+	docker run --platform linux/amd64 --rm -e WASMLABS_RUNTIME -e WASMLABS_TAG=v3_2_0 -v ${ROOT_DIR}/build-output:/wlr/build-output -v ${ROOT_DIR}/build-staging:/wlr/build-staging ghcr.io/vmware-labs/wasmlabs/ruby-builder:wasi-${WASI_SDK_VERSION} ./wl-make.sh ruby/$@
 
 .PHONY: clean
 clean:

--- a/ruby/v3_2_0/wl-build.sh
+++ b/ruby/v3_2_0/wl-build.sh
@@ -10,27 +10,28 @@ cd "${WASMLABS_CHECKOUT_PATH}"
 
 mkdir -p build
 
-logStatus "Downloading autotools data... "
+if [[ -z "$WASMLABS_SKIP_CONFIGURE" ]]; then
+    logStatus "Downloading autotools data... "
+    ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
 
-ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
+    logStatus "Generating configure script... "
+    ./autogen.sh
 
-logStatus "Generating configure script... "
-
-./autogen.sh
-
-logStatus "Configuring ruby..."
-
-./configure \
-    --host wasm32-unknown-wasi \
-    --with-ext=ripper,monitor \
-    --with-static-linked-ext \
-    LDFLAGS=" \
+    logStatus "Configuring ruby..."
+    ./configure \
+        --host wasm32-unknown-wasi \
+        --with-ext=ripper,monitor \
+        --with-static-linked-ext \
+        LDFLAGS=" \
       -Xlinker --stack-first \
       -Xlinker -z -Xlinker stack-size=16777216 \
     " \
-    optflags="-O2" \
-    debugflags="" \
-    wasmoptflags="-O2"
+        optflags="-O2" \
+        debugflags="" \
+        wasmoptflags="-O2"
+else
+    logStatus "Skipping configure..."
+fi
 
 logStatus "Building ruby..."
 make ruby


### PR DESCRIPTION
If the envvar `WASMLABS_SKIP_CONFIGURE` is exported, build scripts will skip the configure step.