### PR TITLE
feat: Updating Docker `wasm-base` image to Ubuntu 22.04 LTS (needed for updating Autotools)

### DIFF
--- a/Dockerfile.wasm-base
+++ b/Dockerfile.wasm-base
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:20.04
+FROM docker.io/library/ubuntu:22.04
 ARG BINARYEN_VERSION
 ENV BINARYEN_PATH=/opt
 RUN apt update && \


### PR DESCRIPTION
Opening this PR to check whether all tests pass if updating the Ubuntu image.