### PR TITLE
feat: Publish builder containers for faster builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,1 @@
-build-output
-build-staging
-
-/libs
-/php
-/python
-/ruby
+*

--- a/.github/workflows/build-php-nightly.yaml
+++ b/.github/workflows/build-php-nightly.yaml
@@ -26,22 +26,22 @@ jobs:
       - name: Rename artifacts
         shell: bash
         run: |
-          sudo mv php/build-output/php/${{ matrix.version }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}}.wasm
+          sudo mv build-output/php/${{ matrix.version }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}}.wasm
       - name: Rename artifacts
         shell: bash
         if: ${{ matrix.build-php-cli }}
         run: |
-          sudo mv php/build-output/php/${{ matrix.version }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}}.wasm
+          sudo mv build-output/php/${{ matrix.version }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}}.wasm
       - name: Upload php-${{ matrix.version }}${{ matrix.suffix }}.wasm artifact
         uses: actions/upload-artifact@v3
         if: ${{ matrix.build-php-cli }}
         with:
           name: php-${{ matrix.version }}${{ matrix.suffix }}.wasm
-          path: php/build-output/php/${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.wasm
+          path: build-output/php/${{ matrix.version }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}.wasm
           if-no-files-found: error
       - name: Upload php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm artifact
         uses: actions/upload-artifact@v3
         with:
           name: php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm
-          path: php/build-output/php/${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm
+          path: build-output/php/${{ matrix.version }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}.wasm
           if-no-files-found: error

--- a/.github/workflows/build-php.yaml
+++ b/.github/workflows/build-php.yaml
@@ -57,22 +57,22 @@ jobs:
       - name: Rename `php-cgi.wasm` binary (adding version and flavor)
         shell: bash
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}}.wasm
+          sudo mv build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}}.wasm
       - name: Rename `php.wasm` binary (CLI) (adding version and flavor)
         shell: bash
         if: ${{ matrix.build-php-cli }}
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}}.wasm
+          sudo mv build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}}.wasm
       - name: Upload php-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}.wasm artifact
         uses: actions/upload-artifact@v3
         if: ${{ matrix.build-php-cli }}
         with:
           name: php-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}.wasm
-          path: php/build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}.wasm
+          path: build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}.wasm
           if-no-files-found: error
       - name: Upload php-cgi-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}.wasm artifact
         uses: actions/upload-artifact@v3
         with:
           name: php-cgi-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}.wasm artifact
-          path: php/build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}.wasm
+          path: build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php-cgi-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}.wasm
           if-no-files-found: error

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -28,12 +28,12 @@ jobs:
       - name: Rename artifacts
         shell: bash
         run: |
-          sudo mv python/build-output/python/v${{ matrix.version }}/bin/python{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}}.wasm
+          sudo mv build-output/python/v${{ matrix.version }}/bin/python{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}}.wasm
       - name: Upload python-aio-${{ matrix.version }}.zip artifact
         uses: actions/upload-artifact@v3
         with:
           name: python-aio-${{ matrix.version }}.zip
           path: |
-            python/build-output/python/v${{ matrix.version }}/bin/python-${{ matrix.version }}${{ matrix.suffix }}.wasm
-            python/build-output/python/v${{ matrix.version }}/usr
+            build-output/python/v${{ matrix.version }}/bin/python-${{ matrix.version }}${{ matrix.suffix }}.wasm
+            build-output/python/v${{ matrix.version }}/usr
           if-no-files-found: error

--- a/.github/workflows/build-ruby.yaml
+++ b/.github/workflows/build-ruby.yaml
@@ -24,10 +24,10 @@ jobs:
       - name: Rename artifacts
         shell: bash
         run: |
-          sudo mv ruby/build-output/ruby/v${{ matrix.target_version }}/bin/ruby{,-${{ matrix.version }}}.wasm
+          sudo mv build-output/ruby/v${{ matrix.target_version }}/bin/ruby{,-${{ matrix.version }}}.wasm
       - name: Upload ruby-${{ matrix.version }}.wasm artifact
         uses: actions/upload-artifact@v3
         with:
           name: ruby-${{ matrix.version }}.wasm
-          path: ruby/build-output/ruby/v${{ matrix.target_version }}/bin/ruby-${{ matrix.version }}.wasm
+          path: build-output/ruby/v${{ matrix.target_version }}/bin/ruby-${{ matrix.version }}.wasm
           if-no-files-found: error

--- a/.github/workflows/build-uuid.yaml
+++ b/.github/workflows/build-uuid.yaml
@@ -31,6 +31,6 @@ jobs:
         with:
           name: libuuid-${{ matrix.version }}
           path: |
-            libs/uuid/build-output/uuid/libuuid-${{ matrix.version }}/include
-            libs/uuid/build-output/uuid/libuuid-${{ matrix.version }}/lib
+            build-output/uuid/libuuid-${{ matrix.version }}/include
+            build-output/uuid/libuuid-${{ matrix.version }}/lib
           if-no-files-found: error

--- a/.github/workflows/build-zlib.yaml
+++ b/.github/workflows/build-zlib.yaml
@@ -31,6 +31,6 @@ jobs:
         with:
           name: zlib-${{ matrix.version }}
           path: |
-            libs/zlib/build-output/zlib/v${{ matrix.version }}/include
-            libs/zlib/build-output/zlib/v${{ matrix.version }}/lib
+            build-output/zlib/v${{ matrix.version }}/include
+            build-output/zlib/v${{ matrix.version }}/lib
           if-no-files-found: error

--- a/.github/workflows/release-php.yaml
+++ b/.github/workflows/release-php.yaml
@@ -73,7 +73,7 @@ jobs:
         if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         shell: bash
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}}.wasm
+          sudo mv build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}}.wasm
       - name: Rename release artifacts
         # Only run for the PHP version specified in the git tag.
         #
@@ -82,7 +82,7 @@ jobs:
         if: ${{ startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version)) && matrix.build-php-cli }}
         shell: bash
         run: |
-          sudo mv php/build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}}.wasm
+          sudo mv build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/php{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}}.wasm
       - name: Create release
         # Only run for the PHP version specified in the git tag.
         #
@@ -103,7 +103,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            php/build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/*.wasm
+            build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/*.wasm
       - name: Generate release assets digests
         # Only run for the PHP version specified in the git tag.
         #
@@ -113,7 +113,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for asset in php/build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/*.wasm; do
+          for asset in build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/*.wasm; do
             sha256sum "$asset" | sudo tee "$asset.sha256sum" > /dev/null
           done
       - name: Append release assets digests
@@ -126,4 +126,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            php/build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/*.sha256sum
+            build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}/bin/*.sha256sum

--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -46,8 +46,8 @@ jobs:
         if: startsWith(github.event.ref, format('refs/tags/python/{0}+', matrix.version))
         shell: bash
         run: |
-          sudo mv python/build-output/python/v${{ matrix.version }}/bin/python{,-${{ matrix.version }}}.wasm
-          sudo mv python/build-output/python/v${{ matrix.version }}/bin/python{,-${{ matrix.version }}}-wasmedge.wasm
+          sudo mv build-output/python/v${{ matrix.version }}/bin/python{,-${{ matrix.version }}}.wasm
+          sudo mv build-output/python/v${{ matrix.version }}/bin/python{,-${{ matrix.version }}}-wasmedge.wasm
       - name: Bundle Python with standard libraries
         # Only run for the Python version specified in the git tag.
         #
@@ -55,7 +55,7 @@ jobs:
         # supported by GitHub (https://github.com/community/community/discussions/37883)
         if: startsWith(github.event.ref, format('refs/tags/python/{0}+', matrix.version))
         run: |
-          pushd python/build-output/python/v${{ matrix.version }}
+          pushd build-output/python/v${{ matrix.version }}
           sudo zip -qq -r python-aio-${{ matrix.version }}.zip bin usr
           popd
       - name: Create release
@@ -78,7 +78,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            python/build-output/python/v${{ matrix.version }}/python-aio-${{ matrix.version }}.zip
+            build-output/python/v${{ matrix.version }}/python-aio-${{ matrix.version }}.zip
       - name: Generate release assets digests
         # Only run for the Python version specified in the git tag.
         #
@@ -88,7 +88,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for asset in python/build-output/python/v${{ matrix.version }}/python-aio-${{ matrix.version }}.zip; do
+          for asset in build-output/python/v${{ matrix.version }}/python-aio-${{ matrix.version }}.zip; do
             sha256sum "$asset" | sudo tee "$asset.sha256sum" > /dev/null
           done
       - name: Append release assets digests
@@ -101,5 +101,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            python/build-output/python/v${{ matrix.version }}/python-aio-${{ matrix.version }}.zip.sha256sum
+            build-output/python/v${{ matrix.version }}/python-aio-${{ matrix.version }}.zip.sha256sum
 

--- a/.github/workflows/release-ruby.yaml
+++ b/.github/workflows/release-ruby.yaml
@@ -40,7 +40,7 @@ jobs:
         if: startsWith(github.event.ref, format('refs/tags/ruby/{0}+', matrix.version))
         shell: bash
         run: |
-          sudo mv ruby/build-output/ruby/v${{ matrix.target_version }}/bin/ruby{,-${{ matrix.version }}}.wasm
+          sudo mv build-output/ruby/v${{ matrix.target_version }}/bin/ruby{,-${{ matrix.version }}}.wasm
       - name: Create release
         # Only run for the Ruby version specified in the git tag.
         #
@@ -61,7 +61,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            ruby/build-output/ruby/v${{ matrix.target_version }}/bin/*.wasm
+            build-output/ruby/v${{ matrix.target_version }}/bin/*.wasm
       - name: Generate release assets digests
         # Only run for the Ruby version specified in the git tag.
         #
@@ -71,7 +71,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for asset in ruby/build-output/ruby/v${{ matrix.target_version }}/bin/*.wasm; do
+          for asset in build-output/ruby/v${{ matrix.target_version }}/bin/*.wasm; do
             sha256sum "$asset" | sudo tee "$asset.sha256sum" > /dev/null
           done
       - name: Append release assets digests
@@ -84,4 +84,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            ruby/build-output/ruby/v${{ matrix.target_version }}/bin/*.sha256sum
+            build-output/ruby/v${{ matrix.target_version }}/bin/*.sha256sum

--- a/.github/workflows/release-uuid.yaml
+++ b/.github/workflows/release-uuid.yaml
@@ -38,7 +38,7 @@ jobs:
         # supported by GitHub (https://github.com/community/community/discussions/37883)
         if: startsWith(github.event.ref, format('refs/tags/libs/uuid/{0}+', matrix.version))
         run: |
-          pushd libs/uuid/build-output/uuid/libuuid-${{ matrix.version }}
+          pushd build-output/uuid/libuuid-${{ matrix.version }}
           sudo zip -qq -r libuuid-${{ matrix.version }}.zip include lib
           popd
       - name: Create release
@@ -61,7 +61,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            libs/uuid/build-output/uuid/libuuid-${{ matrix.version }}/libuuid-${{ matrix.version }}.zip
+            build-output/uuid/libuuid-${{ matrix.version }}/libuuid-${{ matrix.version }}.zip
       - name: Generate release assets digests
         # Only run for the LibUuid version specified in the git tag.
         #
@@ -71,7 +71,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for asset in libs/uuid/build-output/uuid/libuuid-${{ matrix.version }}/libuuid-${{ matrix.version }}.zip; do
+          for asset in build-output/uuid/libuuid-${{ matrix.version }}/libuuid-${{ matrix.version }}.zip; do
             sha256sum "$asset" | sudo tee "$asset.sha256sum" > /dev/null
           done
       - name: Append release assets digests
@@ -84,5 +84,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            libs/uuid/build-output/uuid/libuuid-${{ matrix.version }}/libuuid-${{ matrix.version }}.zip.sha256sum
+            build-output/uuid/libuuid-${{ matrix.version }}/libuuid-${{ matrix.version }}.zip.sha256sum
 

--- a/.github/workflows/release-zlib.yaml
+++ b/.github/workflows/release-zlib.yaml
@@ -38,7 +38,7 @@ jobs:
         # supported by GitHub (https://github.com/community/community/discussions/37883)
         if: startsWith(github.event.ref, format('refs/tags/libs/zlib/{0}+', matrix.version))
         run: |
-          pushd libs/zlib/build-output/zlib/v${{ matrix.version }}
+          pushd build-output/zlib/v${{ matrix.version }}
           sudo zip -qq -r zlib-${{ matrix.version }}.zip include lib
           popd
       - name: Create release
@@ -61,7 +61,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            libs/zlib/build-output/zlib/v${{ matrix.version }}/zlib-${{ matrix.version }}.zip
+            build-output/zlib/v${{ matrix.version }}/zlib-${{ matrix.version }}.zip
       - name: Generate release assets digests
         # Only run for the Zlib version specified in the git tag.
         #
@@ -71,7 +71,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for asset in libs/zlib/build-output/zlib/v${{ matrix.version }}/zlib-${{ matrix.version }}.zip; do
+          for asset in build-output/zlib/v${{ matrix.version }}/zlib-${{ matrix.version }}.zip; do
             sha256sum "$asset" | sudo tee "$asset.sha256sum" > /dev/null
           done
       - name: Append release assets digests
@@ -84,5 +84,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-            libs/zlib/build-output/zlib/v${{ matrix.version }}/zlib-${{ matrix.version }}.zip.sha256sum
+            build-output/zlib/v${{ matrix.version }}/zlib-${{ matrix.version }}.zip.sha256sum
 

--- a/Dockerfile.wasi-builder
+++ b/Dockerfile.wasi-builder
@@ -1,5 +1,4 @@
-ARG WASM_BASE
-FROM ghcr.io/vmware-labs/wasmlabs/wasm-base:${WASM_BASE}
+FROM ghcr.io/vmware-labs/wasmlabs/wasm-base:latest
 ARG WASI_SDK_VERSION
 ARG WABT_VERSION=1.0.32
 ENV WASI_SDK=wasi-sdk-${WASI_SDK_VERSION}
@@ -24,5 +23,7 @@ RUN wget https://github.com/WebAssembly/wabt/releases/download/${WABT_VERSION}/$
       mkdir ${WABT_ROOT} && \
       tar xf ${WABT}-ubuntu.tar.gz --strip-components=1 -C ${WABT_ROOT} && \
       rm ${WABT}-ubuntu.tar.gz
-ADD . /wlr
+RUN mkdir /wlr
+# We will be mounting the source repo in /wlr, which is owned by a user different from root.
+RUN git config --global --add safe.directory /wlr
 WORKDIR /wlr

--- a/Dockerfile.wasm-base
+++ b/Dockerfile.wasm-base
@@ -8,9 +8,9 @@ RUN apt update && \
     tar -xf binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz --strip-components=1 -C /opt && \
     rm binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz && \
     mkdir -p /opt/priority-bin
-# wasm-opt is called in unexpected contexts
-# (https://github.com/llvm/llvm-project/issues/55781). To avoid this,
-# we install a `wasm-opt` wrapper with a higher priority in the PATH
-# that can disable wasm-opt execution when desired.
-ADD scripts/wrappers/wasm-opt /opt/priority-bin/
+
+# We may need to intercept the execution of some tools.
+# So, for convenience, one may use the /opt/priority-bin to do that.
+RUN mkdir -p /opt/priority-bin
+
 ENV PATH="/opt/priority-bin:$PATH:/opt/bin"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ python/wasmedge-v3.11.1:
 .PHONY: oci-python-3.11.1
 oci-python-3.11.1: python/wasmedge-v3.11.1
 	docker build \
-		--build-arg BUILD_OUTPUT_BASE=python/build-output \
 		--build-arg PYTHON_TAG=v3.11.1 \
 		--build-arg PYTHON_BINARY=python-wasmedge.wasm \
 		-t ghcr.io/vmware-labs/python-wasm:3.11.1-latest \

--- a/Makefile.builders
+++ b/Makefile.builders
@@ -1,44 +1,49 @@
 BUILDER_ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
+include Makefile.helpers
+
 .PHONY: wasm-base
-WASM_BASE_TAG ?= $(shell git rev-parse --short HEAD)
-WASM_BASE_NAME := ghcr.io/vmware-labs/wasmlabs/wasm-base:$(WASM_BASE_TAG)
+WASM_BASE_NAME := ghcr.io/vmware-labs/wasmlabs/wasm-base:latest
 wasm-base:
-	@(! docker image inspect $(WASM_BASE_NAME) 1>/dev/null 2>&1 || \
-		test -z "$(keep-containers)" ) && \
+	@echo Building $(WASM_BASE_NAME) in $(BUILDER_ROOT_DIR) ... && \
 	docker build \
 		--platform linux/amd64 \
 		--build-arg BINARYEN_VERSION=111 \
 		-f $(BUILDER_ROOT_DIR)/Dockerfile.wasm-base \
 		-t $(WASM_BASE_NAME) \
-		$(BUILDER_ROOT_DIR) \
-	|| echo "Reusing existing $(WASM_BASE_NAME)"
+		$(BUILDER_ROOT_DIR)
+
+.PHONY: push-wasm-base
+push-wasm-base:
+	@$(call push_container_image,$(WASM_BASE_NAME))
 
 .PHONY: wasi-builder-19
 WASI_BUILDER_19_NAME := ghcr.io/vmware-labs/wasmlabs/wasi-builder:19
-wasi-builder-19: wasm-base
-	@(! docker image inspect $(WASI_BUILDER_19_NAME) 1>/dev/null 2>&1 || \
-		test -z "$(keep-containers)" ) && \
+wasi-builder-19:
+	@echo Building $(WASI_BUILDER_19_NAME) in $(BUILDER_ROOT_DIR) ... && \
 	docker build \
 		--platform linux/amd64 \
-		--build-arg WASM_BASE=$(WASM_BASE_TAG) \
 		--build-arg WASI_SDK_VERSION=19 \
 		-f $(BUILDER_ROOT_DIR)/Dockerfile.wasi-builder \
 		-t $(WASI_BUILDER_19_NAME) \
-		$(BUILDER_ROOT_DIR) \
-	|| echo "Reusing existing $(WASI_BUILDER_19_NAME)"
+		$(BUILDER_ROOT_DIR)
+
+.PHONY: push-wasi-builder-19
+push-wasi-builder-19:
+	@$(call push_container_image,$(WASI_BUILDER_19_NAME))
 
 .PHONY: wasi-builder-16
 WASI_BUILDER_16_NAME := ghcr.io/vmware-labs/wasmlabs/wasi-builder:16
-wasi-builder-16: wasm-base
-	@(! docker image inspect $(WASI_BUILDER_16_NAME) 1>/dev/null 2>&1 || \
-		test -z "$(keep-containers)" ) && \
+wasi-builder-16:
+	@echo Building $(WASI_BUILDER_16_NAME) in $(BUILDER_ROOT_DIR) ... && \
 	docker build \
 		--platform linux/amd64 \
-		--build-arg WASM_BASE=$(WASM_BASE_TAG) \
 		--build-arg WASI_SDK_VERSION=16 \
 		-f $(BUILDER_ROOT_DIR)/Dockerfile.wasi-builder \
 		-t $(WASI_BUILDER_16_NAME) \
-		$(BUILDER_ROOT_DIR) \
-	|| echo "Reusing existing $(WASI_BUILDER_16_NAME)"
+		$(BUILDER_ROOT_DIR)
+
+.PHONY: push-wasi-builder-16
+push-wasi-builder-16:
+	@$(call push_container_image,$(WASI_BUILDER_16_NAME))
 

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -27,16 +27,14 @@ endef
 
 define build_in_container
     $(eval $@_IMAGE_NAME = $(1))
-    $(eval $@_WL_MAKE_TARGET = $(2))
-	mkdir -p build-output build-staging
+    $(eval $@_REPO_ROOT = $(2))
+    $(eval $@_WL_MAKE_TARGET = $(3))
 	docker run \
 		--platform linux/amd64 \
 		--rm \
 		-e WASMLABS_RUNTIME \
-		-v $(ROOT_DIR)/build-output:/wlr/build-output \
-		-v $(ROOT_DIR)/build-staging:/wlr/build-staging \
-		-v $(ROOT_DIR)../:/wlr/ \
-		-v $(ROOT_DIR)../scripts/wrappers/wasm-opt:/opt/priority-bin/wasm-opt \
+		-v $($@_REPO_ROOT):/wlr/ \
+		-v $($@_REPO_ROOT)/scripts/wrappers/wasm-opt:/opt/priority-bin/wasm-opt \
 		$($@_IMAGE_NAME) \
 		./wl-make.sh $($@_WL_MAKE_TARGET)
 endef

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -1,0 +1,42 @@
+define push_container_image
+    $(eval $@_IMAGE_NAME = $(1))
+    @(docker image inspect $($@_IMAGE_NAME) 1>/dev/null 2>&1 || \
+		(echo "Missing $($@_IMAGE_NAME). Cannot push" && false) ) && \
+	echo Pushing $($@_IMAGE_NAME) ... && \
+	echo Authenticating to ghcr.io ... && \
+	docker login ghcr.io && \
+	docker push $($@_IMAGE_NAME) && \
+	docker image rm $($@_IMAGE_NAME) && \
+	echo Pushed and deleted local tag to avoid usage of stale image in future.
+endef
+
+
+define make_builder_image
+    $(eval $@_IMAGE_NAME = $(1))
+    $(eval $@_ROOT_DIR = $(2))
+    $(eval $@_WASI_SDK_VERSION = $(3))
+	@echo Building $($@_IMAGE_NAME) in $($@_ROOT_DIR) ... && \
+	docker build \
+		--platform linux/amd64 \
+		-f $($@_ROOT_DIR)/Dockerfile \
+		--build-arg WASI_SDK_VERSION=$($@_WASI_SDK_VERSION) \
+		-t $($@_IMAGE_NAME) \
+		$($@_ROOT_DIR)
+endef
+
+
+define build_in_container
+    $(eval $@_IMAGE_NAME = $(1))
+    $(eval $@_WL_MAKE_TARGET = $(2))
+	mkdir -p build-output build-staging
+	docker run \
+		--platform linux/amd64 \
+		--rm \
+		-e WASMLABS_RUNTIME \
+		-v $(ROOT_DIR)/build-output:/wlr/build-output \
+		-v $(ROOT_DIR)/build-staging:/wlr/build-staging \
+		-v $(ROOT_DIR)../:/wlr/ \
+		-v $(ROOT_DIR)../scripts/wrappers/wasm-opt:/opt/priority-bin/wasm-opt \
+		$($@_IMAGE_NAME) \
+		./wl-make.sh $($@_WL_MAKE_TARGET)
+endef

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ All you need in order to run these builds is to have `docker` or `podman` availa
 
 - `php/php-7.3.33`, `php/php-7.4.32`, `php/wasmedge-php-7.4.32`,
   `php/php-8.1.11`, `php/php-8.2.0`
-    - Resulting binaries are placed in `php/build-output/php`.
+    - Resulting binaries are placed in `build-output/php`.
 
 - `python/v3.11.1`
-    - Resulting binaries are placed in `python/build-output/python`.
+    - Resulting binaries are placed in `build-output/python`.
 
 - `ruby/v3_2_0`
-    - Resulting binaries are placed in `ruby/build-output/ruby`.
+    - Resulting binaries are placed in `build-output/ruby`.
 
 ## Build strategy
 

--- a/libs/uuid/Makefile
+++ b/libs/uuid/Makefile
@@ -2,8 +2,9 @@ WASI_SDK_VERSION ?= 19
 # NOTE - the default python build is failing with wasi-sdk-19
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT := $(ROOT_DIR)../..
 
-include $(ROOT_DIR)../../Makefile.helpers
+include $(REPO_ROOT)/Makefile.helpers
 
 .PHONY: libuuid-builder
 LIBUUID_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/libuuid-builder:wasi-$(WASI_SDK_VERSION)
@@ -20,8 +21,8 @@ libuuid-builder:
 
 .PHONY: v*
 libuuid-*: libuuid-builder
-	@$(call build_in_container,$(LIBUUID_BUILDER_NAME),libs/uuid/$@)
+	@$(call build_in_container,$(LIBUUID_BUILDER_NAME),$(REPO_ROOT),libs/uuid/$@)
 
 .PHONY: clean
 clean:
-	rm -rf build-output build-staging
+	rm -rf $(REPO_ROOT)/build-output/uuid $(REPO_ROOT)/build-staging/uuid

--- a/libs/uuid/Makefile
+++ b/libs/uuid/Makefile
@@ -3,11 +3,11 @@ WASI_SDK_VERSION ?= 19
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-include ../../Makefile.builders
+include $(ROOT_DIR)../../Makefile.helpers
 
 .PHONY: libuuid-builder
 LIBUUID_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/libuuid-builder:wasi-$(WASI_SDK_VERSION)
-libuuid-builder: wasi-builder-$(WASI_SDK_VERSION)
+libuuid-builder:
 	@(! docker image inspect $(LIBUUID_BUILDER_NAME) 1>/dev/null 2>&1 || \
 		test -z "$(keep-containers)" ) && \
 	docker build \
@@ -20,16 +20,7 @@ libuuid-builder: wasi-builder-$(WASI_SDK_VERSION)
 
 .PHONY: v*
 libuuid-*: libuuid-builder
-	mkdir -p build-output build-staging
-	docker run \
-		--platform linux/amd64 \
-		--rm \
-		-e WASMLABS_RUNTIME \
-		-v $(ROOT_DIR)/build-output:/wlr/build-output \
-		-v $(ROOT_DIR)/build-staging:/wlr/build-staging \
-		-v $(ROOT_DIR):/wlr/libs/uuid \
-		$(LIBUUID_BUILDER_NAME) \
-		./wl-make.sh libs/uuid/$@
+	@$(call build_in_container,$(LIBUUID_BUILDER_NAME),libs/uuid/$@)
 
 .PHONY: clean
 clean:

--- a/libs/zlib/Makefile
+++ b/libs/zlib/Makefile
@@ -3,32 +3,14 @@ WASI_SDK_VERSION ?= 19
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-include ../../Makefile.builders
+include $(ROOT_DIR)../../Makefile.helpers
 
 .PHONY: zlib-builder
-WASI_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/wasi-builder:$(WASI_SDK_VERSION)
-ZLIB_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/zlib-builder:wasi-$(WASI_SDK_VERSION)
-zlib-builder: wasi-builder-$(WASI_SDK_VERSION)
-	(! docker image inspect $(ZLIB_BUILDER_NAME) 1>/dev/null 2>&1 || \
-		test -z "$(keep-containers)" ) && \
-	(docker image rm $(ZLIB_BUILDER_NAME) || true) && \
-	docker tag \
-		`docker images -q $(WASI_BUILDER_NAME)` \
-		$(ZLIB_BUILDER_NAME) \
-	|| echo "Reusing existing $(ZLIB_BUILDER_NAME)"
+ZLIB_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/wasi-builder:$(WASI_SDK_VERSION)
 
 .PHONY: v*
-v*: zlib-builder
-	mkdir -p build-output build-staging
-	docker run \
-		--platform linux/amd64 \
-		--rm \
-		-e WASMLABS_RUNTIME \
-		-v ${ROOT_DIR}/build-output:/wlr/build-output \
-		-v ${ROOT_DIR}/build-staging:/wlr/build-staging \
-		-v $(ROOT_DIR):/wlr/libs/zlib \
-		$(ZLIB_BUILDER_NAME) \
-		./wl-make.sh libs/zlib/$@
+v*:
+	@$(call build_in_container,$(ZLIB_BUILDER_NAME),libs/zlib/$@)
 
 .PHONY: clean
 clean:

--- a/libs/zlib/Makefile
+++ b/libs/zlib/Makefile
@@ -2,16 +2,17 @@ WASI_SDK_VERSION ?= 19
 # NOTE - the default python build is failing with wasi-sdk-19
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT := $(ROOT_DIR)../..
 
-include $(ROOT_DIR)../../Makefile.helpers
+include $(REPO_ROOT)/Makefile.helpers
 
 .PHONY: zlib-builder
 ZLIB_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/wasi-builder:$(WASI_SDK_VERSION)
 
 .PHONY: v*
 v*:
-	@$(call build_in_container,$(ZLIB_BUILDER_NAME),libs/zlib/$@)
+	@$(call build_in_container,$(ZLIB_BUILDER_NAME),$(REPO_ROOT),libs/zlib/$@)
 
 .PHONY: clean
 clean:
-	rm -rf build-output build-staging
+	rm -rf $(REPO_ROOT)/build-output/zlib $(REPO_ROOT)/build-staging/zlib

--- a/php/.dockerignore
+++ b/php/.dockerignore
@@ -1,2 +1,0 @@
-build-output
-build-staging

--- a/php/Makefile
+++ b/php/Makefile
@@ -1,8 +1,9 @@
 WASI_SDK_VERSION ?= 19
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT := $(ROOT_DIR)..
 
-include $(ROOT_DIR)../Makefile.helpers
+include $(REPO_ROOT)/Makefile.helpers
 
 .PHONY: php-builder
 PHP_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/php-builder:wasi-$(WASI_SDK_VERSION)
@@ -15,12 +16,12 @@ push-php-builder:
 
 .PHONY: php-*
 php-*:
-	@$(call build_in_container,$(PHP_BUILDER_NAME),php/$@)
+	@$(call build_in_container,$(PHP_BUILDER_NAME),$(REPO_ROOT),php/$@)
 
 .PHONY: master
 master:
-	@$(call build_in_container,$(PHP_BUILDER_NAME),php/$@)
+	@$(call build_in_container,$(PHP_BUILDER_NAME),$(REPO_ROOT),php/$@)
 
 .PHONY: clean
 clean:
-	rm -rf build-output build-staging
+	rm -rf $(REPO_ROOT)/build-output/php $(REPO_ROOT)/build-staging/php

--- a/php/Makefile
+++ b/php/Makefile
@@ -2,48 +2,24 @@ WASI_SDK_VERSION ?= 19
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-include ../Makefile.builders
+include $(ROOT_DIR)../Makefile.helpers
 
 .PHONY: php-builder
 PHP_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/php-builder:wasi-$(WASI_SDK_VERSION)
-php-builder: wasi-builder-$(WASI_SDK_VERSION)
-	@(! docker image inspect $(PHP_BUILDER_NAME) 1>/dev/null 2>&1 || \
-		test -z "$(keep-containers)" ) && \
-	docker build \
-		--platform linux/amd64 \
-		-f $(ROOT_DIR)/Dockerfile \
-		--build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) \
-		-t $(PHP_BUILDER_NAME) \
-		$(ROOT_DIR) \
-	|| echo "Reusing existing $(PHP_BUILDER_NAME)"
+php-builder:
+	@$(call make_builder_image,$(PHP_BUILDER_NAME),$(ROOT_DIR),$(WASI_SDK_VERSION))
+
+.PHONY: push-php-builder
+push-php-builder:
+	@$(call push_container_image,$(PHP_BUILDER_NAME))
 
 .PHONY: php-*
-php-*: php-builder
-	mkdir -p build-output build-staging
-	docker run \
-		--platform linux/amd64 \
-		--rm \
-		-e WASMLABS_RUNTIME \
-		-v $(ROOT_DIR)/build-output:/wlr/build-output \
-		-v $(ROOT_DIR)/build-staging:/wlr/build-staging \
-		-v $(ROOT_DIR)../libs:/wlr/libs \
-		-v $(ROOT_DIR):/wlr/php \
-		$(PHP_BUILDER_NAME) \
-		./wl-make.sh php/$@
+php-*:
+	@$(call build_in_container,$(PHP_BUILDER_NAME),php/$@)
 
 .PHONY: master
-master: php-builder
-	mkdir -p build-output build-staging
-	docker run \
-		--platform linux/amd64 \
-		--rm \
-		-e WASMLABS_RUNTIME \
-		-v $(ROOT_DIR)/build-output:/wlr/build-output \
-		-v $(ROOT_DIR)/build-staging:/wlr/build-staging \
-		-v $(ROOT_DIR)../libs:/wlr/libs \
-		-v $(ROOT_DIR):/wlr/php \
-		$(PHP_BUILDER_NAME) \
-		./wl-make.sh php/$@
+master:
+	@$(call build_in_container,$(PHP_BUILDER_NAME),php/$@)
 
 .PHONY: clean
 clean:

--- a/python/.dockerignore
+++ b/python/.dockerignore
@@ -1,2 +1,0 @@
-build-output
-build-staging

--- a/python/Makefile
+++ b/python/Makefile
@@ -3,34 +3,20 @@ WASI_SDK_VERSION ?= 16
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-include ../Makefile.builders
+include $(ROOT_DIR)../Makefile.helpers
 
 .PHONY: python-builder
 PYTHON_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/python-builder:wasi-$(WASI_SDK_VERSION)
-python-builder: wasi-builder-$(WASI_SDK_VERSION)
-	@(! docker image inspect $(PYTHON_BUILDER_NAME) 1>/dev/null 2>&1 || \
-		test -z "$(keep-containers)" ) && \
-	docker build \
-		--platform linux/amd64 \
-		-f $(ROOT_DIR)/Dockerfile \
-		--build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) \
-		-t $(PYTHON_BUILDER_NAME) \
-		$(ROOT_DIR) \
-	|| echo "Reusing existing $(PYTHON_BUILDER_NAME)"
+python-builder:
+	@$(call make_builder_image,$(PYTHON_BUILDER_NAME),$(ROOT_DIR),$(WASI_SDK_VERSION))
+
+.PHONY: push-python-builder
+push-python-builder:
+	@$(call push_container_image,$(PYTHON_BUILDER_NAME))
 
 .PHONY: v*
-v*: python-builder
-	mkdir -p build-output build-staging
-	docker run \
-		--platform linux/amd64 \
-		--rm \
-		-e WASMLABS_RUNTIME \
-		-v $(ROOT_DIR)/build-output:/wlr/build-output \
-		-v $(ROOT_DIR)/build-staging:/wlr/build-staging \
-		-v $(ROOT_DIR)../libs:/wlr/libs \
-		-v $(ROOT_DIR):/wlr/python \
-		$(PYTHON_BUILDER_NAME) \
-		./wl-make.sh python/$@
+v*:
+	@$(call build_in_container,$(PYTHON_BUILDER_NAME),python/$@)
 
 .PHONY: clean
 clean:

--- a/python/Makefile
+++ b/python/Makefile
@@ -2,8 +2,9 @@ WASI_SDK_VERSION ?= 16
 # NOTE - the default python build is failing with wasi-sdk-19
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT := $(ROOT_DIR)..
 
-include $(ROOT_DIR)../Makefile.helpers
+include $(REPO_ROOT)/Makefile.helpers
 
 .PHONY: python-builder
 PYTHON_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/python-builder:wasi-$(WASI_SDK_VERSION)
@@ -16,8 +17,8 @@ push-python-builder:
 
 .PHONY: v*
 v*:
-	@$(call build_in_container,$(PYTHON_BUILDER_NAME),python/$@)
+	@$(call build_in_container,$(PYTHON_BUILDER_NAME),$(REPO_ROOT),python/$@)
 
 .PHONY: clean
 clean:
-	rm -rf build-output build-staging
+	rm -rf $(REPO_ROOT)/build-output/python $(REPO_ROOT)/build-staging/python

--- a/ruby/.dockerignore
+++ b/ruby/.dockerignore
@@ -1,2 +1,0 @@
-build-output
-build-staging

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -2,35 +2,20 @@ WASI_SDK_VERSION ?= 19
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-include ../Makefile.builders
+include $(ROOT_DIR)../Makefile.helpers
 
 .PHONY: ruby-builder
 RUBY_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/ruby-builder:wasi-$(WASI_SDK_VERSION)
-ruby-builder: wasi-builder-$(WASI_SDK_VERSION)
-	@(! docker image inspect $(RUBY_BUILDER_NAME) 1>/dev/null 2>&1 || \
-		test -z "$(keep-containers)" ) && \
-	docker build \
-		--platform linux/amd64 \
-		-f $(ROOT_DIR)/Dockerfile \
-		--build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) \
-		-t $(RUBY_BUILDER_NAME) \
-		$(ROOT_DIR) \
-	|| echo "Reusing existing $(RUBY_BUILDER_NAME)"
+ruby-builder:
+	@$(call make_builder_image,$(RUBY_BUILDER_NAME),$(ROOT_DIR),$(WASI_SDK_VERSION))
+
+.PHONY: push-ruby-builder
+push-ruby-builder:
+	@$(call push_container_image,$(RUBY_BUILDER_NAME))
 
 .PHONY: v*
-v*: ruby-builder
-	mkdir -p build-output build-staging
-	docker run \
-		--platform linux/amd64 \
-		--rm \
-		-e WASMLABS_RUNTIME \
-		-e WASMLABS_TAG=v3_2_0 \
-		-v $(ROOT_DIR)/build-output:/wlr/build-output \
-		-v $(ROOT_DIR)/build-staging:/wlr/build-staging \
-		-v $(ROOT_DIR)../libs:/wlr/libs \
-		-v $(ROOT_DIR):/wlr/ruby \
-		$(RUBY_BUILDER_NAME) \
-		./wl-make.sh ruby/$@
+v*:
+	@$(call build_in_container,$(RUBY_BUILDER_NAME),ruby/$@)
 
 .PHONY: clean
 clean:

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,8 +1,9 @@
 WASI_SDK_VERSION ?= 19
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT := $(ROOT_DIR)..
 
-include $(ROOT_DIR)../Makefile.helpers
+include $(REPO_ROOT)/Makefile.helpers
 
 .PHONY: ruby-builder
 RUBY_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/ruby-builder:wasi-$(WASI_SDK_VERSION)
@@ -15,8 +16,8 @@ push-ruby-builder:
 
 .PHONY: v*
 v*:
-	@$(call build_in_container,$(RUBY_BUILDER_NAME),ruby/$@)
+	@$(call build_in_container,$(RUBY_BUILDER_NAME),$(REPO_ROOT),ruby/$@)
 
 .PHONY: clean
 clean:
-	rm -rf build-output build-staging
+	rm -rf $(REPO_ROOT)/build-output/ruby $(REPO_ROOT)/build-staging/ruby


### PR DESCRIPTION
- Basic containers have been published here - https://github.com/orgs/vmware-labs/packages?tab=packages&q=wasmlabs
- Simplify Makefiles by extracting common patterns into Makefile.helpers

Rebuilding and re-publishing of the containers is a manual step.
You will need to call the exact Makefile explicitly. e.g.

```
make -f Makefile.builders wasi-builder-19
make -f Makefile.builders push-wasi-builder-19
```
or

```
make -f php/Makefile php-builder
make -f php/Makefile push-php-builder
``` 