### PR TITLE
chore: only run actions on the main branch

### DIFF
--- a/.github/workflows/build-php.yaml
+++ b/.github/workflows/build-php.yaml
@@ -5,7 +5,7 @@ on:
     # running on tag push. We have a dedicated workflow to be ran when
     # a tag is pushed.
     branches:
-      - "*"
+      - main
   pull_request:
 jobs:
   build-php:

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -5,7 +5,7 @@ on:
     # running on tag push. We have a dedicated workflow to be ran when
     # a tag is pushed.
     branches:
-      - "*"
+      - main
   pull_request:
 jobs:
   build-python:

--- a/.github/workflows/build-ruby.yaml
+++ b/.github/workflows/build-ruby.yaml
@@ -5,7 +5,7 @@ on:
     # running on tag push. We have a dedicated workflow to be ran when
     # a tag is pushed.
     branches:
-      - "*"
+      - main
   pull_request:
 jobs:
   build-ruby:

--- a/.github/workflows/build-uuid.yaml
+++ b/.github/workflows/build-uuid.yaml
@@ -5,7 +5,7 @@ on:
     # running on tag push. We have a dedicated workflow to be ran when
     # a tag is pushed.
     branches:
-      - "*"
+      - main
     paths:
        - ".github/**"
        - "libs/uuid/**"

--- a/.github/workflows/build-zlib.yaml
+++ b/.github/workflows/build-zlib.yaml
@@ -5,7 +5,7 @@ on:
     # running on tag push. We have a dedicated workflow to be ran when
     # a tag is pushed.
     branches:
-      - "*"
+      - main
     paths:
        - ".github/**"
        - "libs/zlib/**"


### PR DESCRIPTION
Given other branches than main will need a PR to merge into main, we will run CI workflows on the PR itself, that contains a trigger of its own.