### PR TITLE
chore: Add host python (for building) in python-builder

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,14 @@
 ARG WASI_SDK_VERSION
+
+FROM ghcr.io/vmware-labs/wasmlabs/wasi-builder:${WASI_SDK_VERSION} as build-host-python
+RUN DEBIAN_FRONTEND=noninteractive apt install -y \
+      zlib1g-dev
+WORKDIR /tmp
+RUN wget -c https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tar.xz && tar -Jxf Python-3.11.0.tar.xz
+WORKDIR /tmp/Python-3.11.0
+RUN ./configure --enable-optimizations --prefix=/opt/python3.11
+RUN make -j4 && make install
+
 FROM ghcr.io/vmware-labs/wasmlabs/wasi-builder:${WASI_SDK_VERSION}
 
 # If more capabilities are required from the build-erpython, consult this
@@ -6,7 +16,8 @@ FROM ghcr.io/vmware-labs/wasmlabs/wasi-builder:${WASI_SDK_VERSION}
 # https://github.com/python/cpython/blob/main/.github/workflows/posix-deps-apt.sh
 RUN DEBIAN_FRONTEND=noninteractive apt install -y \
       tcl \
-      uuid-dev \
-      zlib1g-dev \
       libtool \
       libtool-bin
+COPY --from=build-host-python /opt/python3.11/ /opt/python3.11/
+RUN update-alternatives --install /usr/bin/python3 python3 /opt/python3.11/bin/python3.11 110
+RUN update-alternatives --install /usr/bin/python3.11 python3.11 /opt/python3.11/bin/python3.11 110

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,16 +1,20 @@
 ARG WASI_SDK_VERSION
+ARG PY_VERSION=3.11.0
+ARG PY_SHORT_VERSION=3.11
 
 FROM ghcr.io/vmware-labs/wasmlabs/wasi-builder:${WASI_SDK_VERSION} as build-host-python
+ARG PY_VERSION
+ARG PY_SHORT_VERSION
 RUN DEBIAN_FRONTEND=noninteractive apt install -y \
       zlib1g-dev
 WORKDIR /tmp
-RUN wget -c https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tar.xz && tar -Jxf Python-3.11.0.tar.xz
-WORKDIR /tmp/Python-3.11.0
-RUN ./configure --enable-optimizations --prefix=/opt/python3.11
+RUN wget -c https://www.python.org/ftp/python/${PY_VERSION}/Python-${PY_VERSION}.tar.xz && tar -Jxf Python-${PY_VERSION}.tar.xz
+WORKDIR /tmp/Python-${PY_VERSION}
+RUN ./configure --enable-optimizations --prefix=/opt/python${PY_SHORT_VERSION}
 RUN make -j4 && make install
 
 FROM ghcr.io/vmware-labs/wasmlabs/wasi-builder:${WASI_SDK_VERSION}
-
+ARG PY_SHORT_VERSION
 # If more capabilities are required from the build-erpython, consult this
 # github workflow configuration for a list of possible dependencies -
 # https://github.com/python/cpython/blob/main/.github/workflows/posix-deps-apt.sh
@@ -18,6 +22,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt install -y \
       tcl \
       libtool \
       libtool-bin
-COPY --from=build-host-python /opt/python3.11/ /opt/python3.11/
-RUN update-alternatives --install /usr/bin/python3 python3 /opt/python3.11/bin/python3.11 110
-RUN update-alternatives --install /usr/bin/python3.11 python3.11 /opt/python3.11/bin/python3.11 110
+COPY --from=build-host-python /opt/python${PY_SHORT_VERSION}/ /opt/python${PY_SHORT_VERSION}/
+RUN update-alternatives --install /usr/bin/python3 python3 /opt/python${PY_SHORT_VERSION}/bin/python${PY_SHORT_VERSION} 110
+RUN update-alternatives --install /usr/bin/python${PY_SHORT_VERSION} python${PY_SHORT_VERSION} /opt/python${PY_SHORT_VERSION}/bin/python${PY_SHORT_VERSION} 110

--- a/python/v3.11.1/wl-build.sh
+++ b/python/v3.11.1/wl-build.sh
@@ -8,30 +8,12 @@ fi
 
 cd "${WASMLABS_SOURCE_PATH}"
 
-# The PREFIX for builder-python MUST be outside of the current build as we need
-# a distclean before building for WASI. The distclean will recursively remove
-# all .so files in the current folder, so if builder-python is installed here
-# it will be botched.
-export BUILDER_PYTHON_PREFIX="$(realpath ${WASMLABS_SOURCE_PATH}/../builder-python)"
-
-if ${BUILDER_PYTHON_PREFIX}/bin/python3.11 -c "import sys; import zipfile"
-then
-    logStatus "Using pre-built builder python (on host) from ${BUILDER_PYTHON_PREFIX}... "
-else
-    logStatus "Building builder python (on host) at ${BUILDER_PYTHON_PREFIX}... "
-    mkdir ${BUILDER_PYTHON_PREFIX}
-    make distclean
-    ${WASMLABS_REPO_ROOT}/scripts/wl-hostbuild.sh ./configure --prefix ${BUILDER_PYTHON_PREFIX} || exit 1
-    make install || exit 1
-    make distclean || exit 1
-fi
-
 export CFLAGS_CONFIG="-O0"
 
 export CFLAGS="${CFLAGS_CONFIG} ${CFLAGS_DEPENDENCIES} ${CFLAGS}"
 export LDFLAGS="${LDFLAGS_DEPENDENCIES} ${LDFLAGS}"
 
-export PYTHON_WASM_CONFIGURE="--with-build-python=${BUILDER_PYTHON_PREFIX}/bin/python3.11"
+export PYTHON_WASM_CONFIGURE="--with-build-python=python3"
 
 if [[ "${WASMLABS_RUNTIME}" == "wasmedge" ]]
 then


### PR DESCRIPTION
We were rebuilding python 3.11 on the host in order to build for wasm

Now this is done as part of the python-builder image

Images have been pushed