### PR TITLE
Sqlite 3.41.2

### DIFF
--- a/.github/workflows/build-libs-sqlite.yaml
+++ b/.github/workflows/build-libs-sqlite.yaml
@@ -19,8 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - version: 3.39.2
+        version: [3.39.2, 3.41.2]
     uses: ./.github/workflows/reusable-build-lib.yaml
     with:
       target: sqlite/v${{ matrix.version }}

--- a/libs/sqlite/v3.41.2/patches/0001-Allow-installation-of-headers-and-pkg-config-files-w.patch
+++ b/libs/sqlite/v3.41.2/patches/0001-Allow-installation-of-headers-and-pkg-config-files-w.patch
@@ -1,0 +1,40 @@
+From 13087ac2531143092f5218e86c23b36a85a34c1d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=3D=3FUTF-8=3Fq=3FJesu=3DCC=3D81s=3D20Gonza=3DCC=3D81lez?=
+ =?UTF-8?q?=3F=3D?= <jesusgm@vmware.com>
+Date: Wed, 29 Mar 2023 14:53:21 +0300
+Subject: [PATCH] Allow installation of headers and pkg-config files with the
+ library
+
+
+diff --git a/Makefile.in b/Makefile.in
+index 2a71bd2..c9b0363 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1450,19 +1450,19 @@ threadtest5: sqlite3.c $(TOP)/test/threadtest5.c
+ 
+ # Standard install and cleanup targets
+ #
+-lib_install:	libsqlite3.la
++lib_install:	libsqlite3.la sqlite3.h sqlite3.pc
+ 	$(INSTALL) -d $(DESTDIR)$(libdir)
+ 	$(LTINSTALL) libsqlite3.la $(DESTDIR)$(libdir)
+-
+-install:	sqlite3$(TEXE) lib_install sqlite3.h sqlite3.pc ${HAVE_TCL:1=tcl_install}
+-	$(INSTALL) -d $(DESTDIR)$(bindir)
+-	$(LTINSTALL) sqlite3$(TEXE) $(DESTDIR)$(bindir)
+ 	$(INSTALL) -d $(DESTDIR)$(includedir)
+ 	$(INSTALL) -m 0644 sqlite3.h $(DESTDIR)$(includedir)
+ 	$(INSTALL) -m 0644 $(TOP)/src/sqlite3ext.h $(DESTDIR)$(includedir)
+ 	$(INSTALL) -d $(DESTDIR)$(pkgconfigdir)
+ 	$(INSTALL) -m 0644 sqlite3.pc $(DESTDIR)$(pkgconfigdir)
+ 
++install:	sqlite3$(TEXE) lib_install ${HAVE_TCL:1=tcl_install}
++	$(INSTALL) -d $(DESTDIR)$(bindir)
++	$(LTINSTALL) sqlite3$(TEXE) $(DESTDIR)$(bindir)
++
+ pkgIndex.tcl:
+ 	echo 'package ifneeded sqlite3 $(RELEASE) [list load [file join $$dir libtclsqlite3[info sharedlibextension]] sqlite3]' > $@
+ tcl_install:	lib_install libtclsqlite3.la pkgIndex.tcl
+-- 
+2.38.1
+

--- a/libs/sqlite/v3.41.2/wlr-build.sh
+++ b/libs/sqlite/v3.41.2/wlr-build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+if [[ ! -v WLR_ENV ]]
+then
+    echo "WLR build environment is not set"
+    exit 1
+fi
+
+export CFLAGS_CONFIG="-O0"
+
+
+# We need to add LDFLAGS ot CFLAGS because autoconf compiles(+links) to binary when checking stuff
+export CFLAGS="${CFLAGS_CONFIG}"
+
+cd "${WLR_SOURCE_PATH}"
+
+source ${WLR_REPO_ROOT}/scripts/build-helpers/wlr_pkg_config.sh
+
+unset WASI_SYSROOT
+unset CC
+unset LD
+unset CXX
+unset NM
+unset AR
+unset RANLIB
+
+if [[ -z "$WLR_SKIP_CONFIGURE" ]]; then
+    export SQLITE_CONFIGURE="${WLR_CONFIGURE_PREFIXES} --enable-all --with-wasi-sdk=${WASI_SDK_PATH}"
+    logStatus "Configuring build with '${SQLITE_CONFIGURE}'..."
+    ./configure --config-cache ${SQLITE_CONFIGURE} || exit 1
+else
+    logStatus "Skipping configure..."
+fi
+
+logStatus "Building... "
+make -j || exit 1
+
+logStatus "Preparing artifacts... "
+make lib_install ${WLR_INSTALL_PREFIXES} || exit 1
+
+wlr_package_lib
+
+logStatus "DONE. Artifacts in ${WLR_OUTPUT}"

--- a/libs/sqlite/v3.41.2/wlr-env-repo.sh
+++ b/libs/sqlite/v3.41.2/wlr-env-repo.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [[ $1 == "--unset" ]]
+then
+    unset WLR_REPO
+    unset WLR_REPO_BRANCH
+    unset WLR_ENV_NAME
+    unset WLR_PACKAGE_VERSION
+    unset WLR_PACKAGE_NAME
+    return
+fi
+
+export WLR_REPO=https://github.com/sqlite/sqlite.git
+export WLR_REPO_BRANCH=version-3.41.2
+export WLR_ENV_NAME=sqlite/v3.41.2
+export WLR_PACKAGE_VERSION=3.41.2
+export WLR_PACKAGE_NAME=sqlite

--- a/libs/sqlite/v3.41.2/wlr-tag.sh
+++ b/libs/sqlite/v3.41.2/wlr-tag.sh
@@ -1,0 +1,1 @@
+export WLR_TAG="libs/sqlite/3.41.2"


### PR DESCRIPTION
Add build for sqlite 3.41.2.

 - latest sqlite version
 - build uses the upstream `--with-wasi-sdk` instead of configuring it manually

Specifically, this is the build check for this version passing - https://github.com/vmware-labs/webassembly-language-runtimes/actions/runs/4553726443/jobs/8030648775?pr=85

Here is a sample release - https://github.com/assambar/webassembly-language-runtimes/releases/tag/libs%2Fsqlite%2F3.41.2%2B20230329-3d86e1b