### PR TITLE
Add fastcgi and client side sockets to PHP8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 # Except this file
 !.gitignore
 .wlr-local-conf.sh
+wlr-tmp

--- a/php/examples/mysql/run_me.sh
+++ b/php/examples/mysql/run_me.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+if [[ "$(realpath $PWD)" != "$(realpath $(dirname $BASH_SOURCE))" ]]
+then
+  echo "This script works only if called from its location as PWD"
+  exit 1
+fi
+
+step_count=0
+demo_step () {
+  echo
+  echo "================================================"
+  echo "Step ${step_count} | $(date --iso-8601=s) | $@"
+  step_count=$(expr $step_count + 1)
+}
+
+export TEST_USER=test_user
+export TEST_PASSWORD=test_password
+export MYSQL_CONTAINER_NAME=mysql-wlr-php-test
+export TEST_DB_PATH=$PWD/wlr-tmp/data
+export TEST_DB=test_db
+
+demo_step Cleanup pre-existing data in "'${TEST_DB_PATH}'" and container "'${MYSQL_CONTAINER_NAME}'"
+docker stop ${MYSQL_CONTAINER_NAME}
+docker rm -f ${MYSQL_CONTAINER_NAME}
+sudo rm -rf ${TEST_DB_PATH}
+if (docker ps -a | grep ${MYSQL_CONTAINER_NAME} 2>/dev/null); then
+    echo "Failed to remove the ${MYSQL_CONTAINER_NAME} container"
+    exit 1
+fi
+
+demo_step Run the mysql container "'${MYSQL_CONTAINER_NAME}'". User 'root', password 'root'
+docker run -d --name ${MYSQL_CONTAINER_NAME} -p 3306:3306 -v ${TEST_DB_PATH}:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=root mysql
+until nc -z localhost 3306
+do
+    echo "Waiting for container to start..."
+    sleep 1
+done
+
+until docker exec ${MYSQL_CONTAINER_NAME} mysql -uroot -proot
+do
+    echo "Waiting for mysqld to become ready..."
+    sleep 10
+done
+
+demo_step Create ${TEST_DB}
+docker exec ${MYSQL_CONTAINER_NAME} mysql -uroot -proot -e "CREATE DATABASE ${TEST_DB};"
+
+demo_step Create sample tables in the ${TEST_DB} database
+docker exec ${MYSQL_CONTAINER_NAME} mysql -h 127.0.0.1 -P 3306  -uroot -proot ${TEST_DB} -e \
+  'CREATE TABLE IF NOT EXISTS test1 (id int(10) NOT NULL AUTO_INCREMENT, name varchar(50) NOT NULL DEFAULT "", PRIMARY KEY(id) )'
+docker exec ${MYSQL_CONTAINER_NAME} mysql -h 127.0.0.1  -P 3306 -uroot -proot ${TEST_DB} -e 'show tables'
+
+demo_step "Configure ${TEST_USER}@ANYHOST / ${TEST_PASSWORD} for mysql_native_password authentication. We don't have OpenSSL, so no sha2 in mysqld in PHP"
+sleep 1
+docker exec ${MYSQL_CONTAINER_NAME} mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "CREATE USER '${TEST_USER}'@'%' IDENTIFIED WITH mysql_native_password BY '${TEST_PASSWORD}'"
+docker exec ${MYSQL_CONTAINER_NAME} mysql -h 127.0.0.1 -P 3306 -uroot -proot ${TEST_DB} -e "GRANT ALL PRIVILEGES ON ${TEST_DB}.* TO '${TEST_USER}'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+
+demo_step "Change default authentication plugin"
+sleep 1
+docker exec ${MYSQL_CONTAINER_NAME} sed -i 's!# default-authentication-plugin=mysql_native_password!default-authentication-plugin=mysql_native_password!g' /etc/my.cnf
+docker restart ${MYSQL_CONTAINER_NAME}
+
+demo_step "Show users and tables"
+sleep 1
+docker exec ${MYSQL_CONTAINER_NAME} mysql -h 127.0.0.1 -P 3306 -uroot -proot mysql -e 'SHOW VARIABLES LIKE "default_authentication_plugin"';
+docker exec ${MYSQL_CONTAINER_NAME} mysql -h 127.0.0.1 -P 3306 -uroot -proot mysql -e "SELECT User,Host,plugin,password_last_changed FROM user WHERE User='${TEST_USER}';"
+docker exec ${MYSQL_CONTAINER_NAME} mysql -h 127.0.0.1 -P 3306 -uroot -proot mysql -e "SHOW GRANTS FOR ${TEST_USER};";
+
+demo_step "Validate access for user '${TEST_USER}'"
+sleep 1
+docker exec ${MYSQL_CONTAINER_NAME} mysql -h 127.0.0.1 -P 3306 -u${TEST_USER} -p${TEST_PASSWORD} ${TEST_DB} -e "show tables";
+docker exec ${MYSQL_CONTAINER_NAME} mysql -h 127.0.0.1 -P 3306 -u${TEST_USER} -p${TEST_PASSWORD} ${TEST_DB} -e \
+    "CREATE TABLE sample(id INT(2) PRIMARY KEY, name VARCHAR(30) NOT NULL, description VARCHAR(30) NOT NULL);"
+
+
+demo_step Build PHP if not available
+# TODO - download from github after release
+if [ ! -f ../../../build-output/php/php-8.2.0-wasmedge/bin/php-wasmedge.wasm ];
+then
+  (cd ../../..; WLR_BUILD_FLAVOR=wasmedge ./wlr-make.sh php/php-8.2.0) || exit 1
+fi
+
+demo_step Test mySQL with PHP.
+sleep 1
+wasmedge --dir /test:$(pwd) --env TEST_USER=${TEST_USER} --env TEST_PASSWORD=${TEST_PASSWORD} ../../../build-output/php/php-8.2.0-wasmedge/bin/php-wasmedge.wasm -f /test/test_mysql.php

--- a/php/examples/mysql/test_mysql.php
+++ b/php/examples/mysql/test_mysql.php
@@ -1,0 +1,58 @@
+<?php
+  $user = getenv('TEST_USER') ? getenv('TEST_USER') : 'test_user';
+  $password = getenv('TEST_PASSWORD') ? getenv('TEST_PASSWORD') : 'test_password';
+  $host = getenv('TEST_HOST') ? getenv('TEST_HOST') : '127.0.0.1';
+  $port = getenv('TEST_PORT') ? getenv('TEST_PORT') : '3306';
+  $db_name = getenv('TEST_DB') ? getenv('TEST_DB') : 'test_db';
+  $connection_string = "mysql:host=$host;port=$port;dbname=$db_name";
+
+  # Connect to the database
+  print("\n");
+  print("Connecting with connection_string=$connection_string, user=$user, password=$password...\n\n");
+  $conn = new PDO($connection_string, $user, $password);
+
+  # Show all tables
+  $tableList = array();
+  $result = $conn->query("SHOW TABLES");
+  while ($row = $result->fetch(PDO::FETCH_NUM)) {
+      $tableList[] = $row[0];
+  }
+  print_r($tableList);
+
+
+  # Create a new table
+  print("\n");
+  $table_name="Sample";
+  print("Creating table '$table_name'...\n");
+  $sql_create_sample = "
+    DROP TABLE IF EXISTS $table_name;
+    CREATE TABLE $table_name(
+      id INT(2) PRIMARY KEY NOT NULL AUTO_INCREMENT,
+      name VARCHAR(30) NOT NULL,
+      description VARCHAR(30)
+    )";
+  $conn->exec($sql_create_sample);
+  print("Table '$table_name' created!\n");
+
+
+  # Insert values into table
+  print("\n");
+  print("Inserting three records into '$table_name'...\n");
+  $sql_insert_sample = "
+    INSERT INTO Sample(Name, Description) VALUES('First', 'Original sample');
+    INSERT INTO Sample(Name, Description) VALUES('Second', 'Secondary sample');
+    INSERT INTO Sample(Name) VALUES('Third');
+  ";
+  $conn->exec($sql_insert_sample);
+  print("Inserted rows into $table_name!\n");
+
+
+  # Select values from table
+  print("\n");
+  print("Selecting all from '$table_name'...\n");
+  $query = $conn->prepare("SELECT * FROM $table_name");
+  $query->execute();
+
+  $selection_result = $query->fetchAll(\PDO::FETCH_ASSOC);
+  print_r($selection_result);
+?>

--- a/php/php-8.2.0/patches/0010-chore-Add-more-logs-in-wasi_socket_ext.patch
+++ b/php/php-8.2.0/patches/0010-chore-Add-more-logs-in-wasi_socket_ext.patch
@@ -1,0 +1,42 @@
+From abac8566212b39d58a519240f2af2c374947e312 Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Thu, 30 Mar 2023 09:29:55 +0300
+Subject: [PATCH 10/15] chore: Add more logs in wasi_socket_ext
+
+ 100.0% wasmedge_stubs/
+
+ 100.0% wasmedge_stubs/
+diff --git a/wasmedge_stubs/wasi_socket_ext.c b/wasmedge_stubs/wasi_socket_ext.c
+index 0c74c75a..5a2a3d26 100644
+--- a/wasmedge_stubs/wasi_socket_ext.c
++++ b/wasmedge_stubs/wasi_socket_ext.c
+@@ -184,6 +184,7 @@ int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_setsockopt(
+ 
+ int socket(int domain, int type, int protocol)
+ {
++  WSEDEBUG("WWSock| socket called: %d, %d, %d \n", domain, type, protocol);
+   int fd;
+   address_family_t af = (domain == AF_INET ? kInet4 : kInet6);
+   socket_type_t st = (type == SOCK_STREAM ? kStream : kDatagram);
+@@ -191,6 +192,7 @@ int socket(int domain, int type, int protocol)
+   if (0 != res) {
+     errno = res;
+     printf("socket err: %s \n", strerror(errno));
++    WSEDEBUG("WWSock| socket failed with error: %s \n", strerror(errno));
+     return -1;
+   }
+   WSEDEBUG("WWSock| socket returning: %d \n", fd);
+@@ -271,8 +273,10 @@ int accept(int fd, struct sockaddr *restrict addr, socklen_t *restrict len) {
+       fd, (uint32_t *)&new_sockfd);
+   if (res != 0) {
+     errno = res;
++    WSEDEBUG("WWSock| accept[%d]: failed=%d\n", __LINE__, errno);
+     return -1;
+   }
++  WSEDEBUG("WWSock| accept[%d]: client_fd=%d\n", __LINE__, new_sockfd);
+   return new_sockfd;
+ }
+ 
+-- 
+2.38.1
+

--- a/php/php-8.2.0/patches/0011-fix-fastcgi-server-in-php-cgi-for-wasmedge.patch
+++ b/php/php-8.2.0/patches/0011-fix-fastcgi-server-in-php-cgi-for-wasmedge.patch
@@ -1,0 +1,165 @@
+From abee46438d070b0b826baf4dfbff6f0dfe6c2b88 Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Thu, 30 Mar 2023 16:23:01 +0300
+Subject: [PATCH 11/15] fix: fastcgi server in php-cgi for wasmedge
+
+ 100.0% main/
+
+ 100.0% main/
+diff --git a/main/fastcgi.c b/main/fastcgi.c
+index ec29595e..742a44c8 100644
+--- a/main/fastcgi.c
++++ b/main/fastcgi.c
+@@ -69,11 +69,16 @@ static int is_impersonate = 0;
+ # include <netinet/in.h>
+ # include <netinet/tcp.h>
+ # include <arpa/inet.h>
+-# ifndef WASM_WASI
++# ifndef __wasi__
+ # include <netdb.h>
+-# endif // WASM_WASI
++# endif // __wasi__
+ # include <signal.h>
+ 
++#ifdef WASM_RUNTIME_WASMEDGE
++#include "wasmedge_stubs/netdb.h"
++#include "wasmedge_stubs/wasi_socket_ext.h"
++#endif
++
+ # if defined(HAVE_POLL_H) && defined(HAVE_POLL)
+ #  include <poll.h>
+ # elif defined(HAVE_SYS_POLL_H) && defined(HAVE_POLL)
+@@ -433,7 +438,7 @@ static void fcgi_signal_handler(int signo)
+ 
+ static void fcgi_setup_signals(void)
+ {
+-#ifndef WASM_WASI
++#ifndef __wasi__
+ 	struct sigaction new_sa, old_sa;
+ 
+ 	sigemptyset(&new_sa.sa_mask);
+@@ -445,7 +450,7 @@ static void fcgi_setup_signals(void)
+ 	if (old_sa.sa_handler == SIG_DFL) {
+ 		sigaction(SIGPIPE, &new_sa, NULL);
+ 	}
+-#endif // WASM_WASI
++#endif // __wasi__
+ }
+ #endif
+ 
+@@ -530,7 +535,9 @@ int fcgi_init(void)
+ 		} else {
+ 			return is_fastcgi = 0;
+ 		}
+-#elif defined(WASM_WASI)
++#elif defined(__wasi__)
++		// This should be 1 if we were spawned as a fastcgi process by an external manager.
++		// Otherwise, if listening as a fastcgi server - the only thing supported by Wasi, we should return 0 here.
+ 		return is_fastcgi = 0;
+ #else
+ 		errno = 0;
+@@ -681,7 +688,14 @@ int fcgi_listen(const char *path, int backlog)
+ 
+ 	/* Prepare socket address */
+ 	if (tcp) {
+-#ifndef WASM_WASI
++#ifdef WASM_RUNTIME_WASMEDGE
++		memset(&sa.sa_inet, 0, sizeof(sa.sa_inet));
++		sa.sa_inet.sin_family = AF_INET;
++		sa.sa_inet.sin_addr.s_addr = INADDR_ANY;
++		sa.sa_inet.sin_port = port;
++		sock_len = sizeof(sa.sa_inet);
++#endif
++#ifndef __wasi__
+ 		memset(&sa.sa_inet, 0, sizeof(sa.sa_inet));
+ 		sa.sa_inet.sin_family = AF_INET;
+ 		sa.sa_inet.sin_port = htons(port);
+@@ -713,6 +727,7 @@ int fcgi_listen(const char *path, int backlog)
+ 				sa.sa_inet.sin_addr.s_addr = ((struct in_addr*)hep->h_addr_list[0])->s_addr;
+ 			}
+ 		}
++#endif // __wasi__
+ 	} else {
+ #ifdef _WIN32
+ 		SECURITY_DESCRIPTOR  sd;
+@@ -740,7 +755,7 @@ int fcgi_listen(const char *path, int backlog)
+ 		is_fastcgi = 1;
+ 		return listen_socket;
+ 
+-#else
++#elif !defined(__wasi__)
+ 		size_t path_len = strlen(path);
+ 
+ 		if (path_len >= sizeof(sa.sa_unix.sun_path)) {
+@@ -759,9 +774,10 @@ int fcgi_listen(const char *path, int backlog)
+ #endif
+ 	}
+ 
++#if !defined(__wasi__) || defined(WASM_RUNTIME_WASMEDGE)
+ 	/* Create, bind socket and start listen on it */
+ 	if ((listen_socket = socket(sa.sa.sa_family, SOCK_STREAM, 0)) < 0 ||
+-#ifdef SO_REUSEADDR
++#if defined(SO_REUSEADDR) && !defined(__wasi__)
+ 	    setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, (char*)&reuse, sizeof(reuse)) < 0 ||
+ #endif
+ 	    bind(listen_socket, (struct sockaddr *) &sa, sock_len) < 0 ||
+@@ -770,11 +786,13 @@ int fcgi_listen(const char *path, int backlog)
+ 		fcgi_log(FCGI_ERROR, "Cannot bind/listen socket - [%d] %s.\n",errno, strerror(errno));
+ 		return -1;
+ 	}
++#endif
+ 
+ 	if (!tcp) {
++#ifndef __wasi__
+ 		chmod(path, 0777);
++#endif // __wasi__
+ 	} else {
+-#endif // WASM_WASI
+ 		char *ip = getenv("FCGI_WEB_SERVER_ADDRS");
+ 		char *cur, *end;
+ 		int n;
+@@ -947,6 +965,8 @@ static inline ssize_t safe_write(fcgi_request *req, const void *buf, size_t coun
+ 				errno = WSAGetLastError();
+ 			}
+ 		}
++#elif defined(__wasi__)
++		ret = send(req->fd, ((char*)buf)+n, count-n, 0);
+ #else
+ 		ret = write(req->fd, ((char*)buf)+n, count-n);
+ #endif
+@@ -984,6 +1004,8 @@ static inline ssize_t safe_read(fcgi_request *req, const void *buf, size_t count
+ 				errno = WSAGetLastError();
+ 			}
+ 		}
++#elif defined(__wasi__)
++		ret = recv(req->fd, ((char*)buf)+n, count-n, 0);
+ #else
+ 		ret = read(req->fd, ((char*)buf)+n, count-n);
+ #endif
+@@ -1107,9 +1129,9 @@ static int fcgi_read_request(fcgi_request *req)
+ 			int on = 1;
+ # endif
+ 
+-# ifndef WASM_WASI
++# ifndef __wasi__
+ 			setsockopt(req->fd, IPPROTO_TCP, TCP_NODELAY, (char*)&on, sizeof(on));
+-# endif // WASM_WASI
++# endif // __wasi__
+ 			req->nodelay = 1;
+ 		}
+ #endif
+@@ -1419,9 +1441,9 @@ int fcgi_accept_request(fcgi_request *req)
+ 					client_sa = sa;
+ 					if (req->fd >= 0 && !fcgi_is_allowed()) {
+ 						fcgi_log(FCGI_ERROR, "Connection disallowed: IP address '%s' has been dropped.", fcgi_get_last_client_ip());
+-#ifndef WASM_WASI
++#ifndef __wasi__
+ 						closesocket(req->fd);
+-#endif // WASM_WASI
++#endif // __wasi__
+ 						req->fd = -1;
+ 						continue;
+ 					}
+-- 
+2.38.1
+

--- a/php/php-8.2.0/patches/0012-chore-Add-debug-logging-in-fastcgi.patch
+++ b/php/php-8.2.0/patches/0012-chore-Add-debug-logging-in-fastcgi.patch
@@ -1,0 +1,275 @@
+From bae64309c29550f41f473ffcb2672f19684d3769 Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Thu, 30 Mar 2023 18:17:16 +0300
+Subject: [PATCH 12/15] chore: Add debug logging in fastcgi
+
+ 100.0% main/
+
+ 100.0% main/
+diff --git a/main/fastcgi.c b/main/fastcgi.c
+index 742a44c8..ab4b4b12 100644
+--- a/main/fastcgi.c
++++ b/main/fastcgi.c
+@@ -137,6 +137,14 @@ static int is_impersonate = 0;
+ 
+ #include "fastcgi.h"
+ 
++// #define FASTCGI_DEBUG
++
++#ifdef FASTCGI_DEBUG
++#define FCGIDEBUG(fmt, ...) fprintf(stderr, fmt __VA_OPT__(,) __VA_ARGS__)
++#else
++#define FCGIDEBUG(fmt, ...)
++#endif
++
+ typedef struct _fcgi_header {
+ 	unsigned char version;
+ 	unsigned char type;
+@@ -490,6 +498,7 @@ void __attribute__((weak)) fcgi_log(int type, const char *format, ...) {
+ 
+ int fcgi_init(void)
+ {
++	FCGIDEBUG("(%s)[%d] fcgi_init\n",__FILE__, __LINE__);
+ 	if (!is_initialized) {
+ #ifndef _WIN32
+ 		sa_t sa;
+@@ -498,6 +507,7 @@ int fcgi_init(void)
+ 		zend_hash_init(&fcgi_mgmt_vars, 8, NULL, fcgi_free_mgmt_var_cb, 1);
+ 		fcgi_set_mgmt_var("FCGI_MPXS_CONNS", sizeof("FCGI_MPXS_CONNS")-1, "0", sizeof("0")-1);
+ 
++		FCGIDEBUG("(%s)[%d] is_initialized=1\n",__FILE__, __LINE__);
+ 		is_initialized = 1;
+ #ifdef _WIN32
+ # if 0
+@@ -556,6 +566,7 @@ int fcgi_init(void)
+ int fcgi_is_fastcgi(void)
+ {
+ 	if (!is_initialized) {
++		FCGIDEBUG("(%s)[%d] before fcgi_init\n",__FILE__, __LINE__);
+ 		return fcgi_init();
+ 	} else {
+ 		return is_fastcgi;
+@@ -656,6 +667,7 @@ static int is_port_number(const char *bindpath)
+ 
+ int fcgi_listen(const char *path, int backlog)
+ {
++	FCGIDEBUG("(%s)[%d] fcgi_listen(%s, %d)\n",__FILE__, __LINE__, path, backlog);
+ 	char     *s;
+ 	int       tcp = 0;
+ 	char      host[MAXPATHLEN];
+@@ -729,6 +741,7 @@ int fcgi_listen(const char *path, int backlog)
+ 		}
+ #endif // __wasi__
+ 	} else {
++		FCGIDEBUG("(%s)[%d] else, for if(tcp)\n",__FILE__, __LINE__);
+ #ifdef _WIN32
+ 		SECURITY_DESCRIPTOR  sd;
+ 		SECURITY_ATTRIBUTES  saw;
+@@ -750,6 +763,7 @@ int fcgi_listen(const char *path, int backlog)
+ 		}
+ 		listen_socket = _open_osfhandle((intptr_t)namedPipe, 0);
+ 		if (!is_initialized) {
++			FCGIDEBUG("(%s)[%d] before fcgi_init\n",__FILE__, __LINE__);
+ 			fcgi_init();
+ 		}
+ 		is_fastcgi = 1;
+@@ -783,6 +797,7 @@ int fcgi_listen(const char *path, int backlog)
+ 	    bind(listen_socket, (struct sockaddr *) &sa, sock_len) < 0 ||
+ 	    listen(listen_socket, backlog) < 0) {
+ 		close(listen_socket);
++		FCGIDEBUG("(%s)[%d] Cannot bind/listen socket\n",__FILE__, __LINE__);
+ 		fcgi_log(FCGI_ERROR, "Cannot bind/listen socket - [%d] %s.\n",errno, strerror(errno));
+ 		return -1;
+ 	}
+@@ -798,6 +813,7 @@ int fcgi_listen(const char *path, int backlog)
+ 		int n;
+ 
+ 		if (ip) {
++			FCGIDEBUG("(%s)[%d] FCGI_WEB_SERVER_ADDRS ip=%s\n",__FILE__, __LINE__, ip);
+ 			ip = strdup(ip);
+ 			cur = ip;
+ 			n = 0;
+@@ -823,6 +839,7 @@ int fcgi_listen(const char *path, int backlog)
+ 					n++;
+ #endif
+ 				} else {
++					FCGIDEBUG("(%s)[%d] Wrong IP address '%s' in listen.allowed_clients\n",__FILE__, __LINE__, cur);
+ 					fcgi_log(FCGI_ERROR, "Wrong IP address '%s' in listen.allowed_clients", cur);
+ 				}
+ 				cur = end;
+@@ -830,6 +847,7 @@ int fcgi_listen(const char *path, int backlog)
+ 			allowed_clients[n].sa.sa_family = 0;
+ 			free(ip);
+ 			if (!n) {
++				FCGIDEBUG("(%s)[%d] NO allowed addresses\n",__FILE__, __LINE__);
+ 				fcgi_log(FCGI_ERROR, "There are no allowed addresses");
+ 				/* don't clear allowed_clients as it will create an "open for all" security issue */
+ 			}
+@@ -837,8 +855,10 @@ int fcgi_listen(const char *path, int backlog)
+ 	}
+ 
+ 	if (!is_initialized) {
++		FCGIDEBUG("(%s)[%d] before fcgi_init\n",__FILE__, __LINE__);
+ 		fcgi_init();
+ 	}
++	FCGIDEBUG("(%s)[%d] is_fastcgi = 1;\n",__FILE__, __LINE__);
+ 	is_fastcgi = 1;
+ 
+ #ifdef _WIN32
+@@ -846,13 +866,16 @@ int fcgi_listen(const char *path, int backlog)
+ 		listen_socket = _open_osfhandle((intptr_t)listen_socket, 0);
+ 	}
+ #else
++	FCGIDEBUG("(%s)[%d] before fcgi_setup_signals;\n",__FILE__, __LINE__);
+ 	fcgi_setup_signals();
+ #endif
++	FCGIDEBUG("(%s)[%d] returning listen_socket=%d;\n",__FILE__, __LINE__, listen_socket);
+ 	return listen_socket;
+ }
+ 
+ void fcgi_set_allowed_clients(char *ip)
+ {
++	FCGIDEBUG("(%s)[%d] fcgi_set_allowed_clients ip=%s\n",__FILE__, __LINE__, ip);
+ 	char *cur, *end;
+ 	int n;
+ 
+@@ -883,6 +906,7 @@ void fcgi_set_allowed_clients(char *ip)
+ 				n++;
+ #endif
+ 			} else {
++				FCGIDEBUG("(%s)[%d] Wrong IP address '%s' in listen.allowed_clients\n",__FILE__, __LINE__, cur);
+ 				fcgi_log(FCGI_ERROR, "Wrong IP address '%s' in listen.allowed_clients", cur);
+ 			}
+ 			cur = end;
+@@ -890,6 +914,7 @@ void fcgi_set_allowed_clients(char *ip)
+ 		allowed_clients[n].sa.sa_family = 0;
+ 		free(ip);
+ 		if (!n) {
++			FCGIDEBUG("(%s)[%d] No allowed addresses\n",__FILE__, __LINE__);
+ 			fcgi_log(FCGI_ERROR, "There are no allowed addresses");
+ 			/* don't clear allowed_clients as it will create an "open for all" security issue */
+ 		}
+@@ -1072,6 +1097,7 @@ static int fcgi_get_params(fcgi_request *req, unsigned char *p, unsigned char *e
+ 
+ static int fcgi_read_request(fcgi_request *req)
+ {
++	FCGIDEBUG("(%s)[%d] fcgi_read_request\n",__FILE__, __LINE__);
+ 	fcgi_header hdr;
+ 	int len, padding;
+ 	unsigned char buf[FCGI_MAX_LENGTH+8];
+@@ -1090,12 +1116,14 @@ static int fcgi_read_request(fcgi_request *req)
+ 
+ 	if (safe_read(req, &hdr, sizeof(fcgi_header)) != sizeof(fcgi_header) ||
+ 	    hdr.version < FCGI_VERSION_1) {
++		FCGIDEBUG("(%s)[%d] failed to read header=%d\n",__FILE__, __LINE__, hdr.version);
+ 		return 0;
+ 	}
+ 
+ 	len = (hdr.contentLengthB1 << 8) | hdr.contentLengthB0;
+ 	padding = hdr.paddingLength;
+ 
++	FCGIDEBUG("(%s)[%d] len=%d, padding=%d\n",__FILE__, __LINE__, len, padding);
+ 	while (hdr.type == FCGI_STDIN && len == 0) {
+ 		if (safe_read(req, &hdr, sizeof(fcgi_header)) != sizeof(fcgi_header) ||
+ 		    hdr.version < FCGI_VERSION_1) {
+@@ -1106,6 +1134,7 @@ static int fcgi_read_request(fcgi_request *req)
+ 		padding = hdr.paddingLength;
+ 	}
+ 
++	FCGIDEBUG("(%s)[%d] len + padding=%d\n",__FILE__, __LINE__, len, padding);
+ 	if (len + padding > FCGI_MAX_LENGTH) {
+ 		return 0;
+ 	}
+@@ -1352,12 +1381,15 @@ int fcgi_is_closed(fcgi_request *req)
+ }
+ 
+ static int fcgi_is_allowed(void) {
++	FCGIDEBUG("(%s)[%d] fcgi_is_allowed\n",__FILE__, __LINE__);
+ 	int i;
+ 
+ 	if (client_sa.sa.sa_family == AF_UNIX) {
++		FCGIDEBUG("(%s)[%d] client_sa.sa.sa_family == AF_UNIX\n",__FILE__, __LINE__);
+ 		return 1;
+ 	}
+ 	if (!allowed_clients) {
++		FCGIDEBUG("(%s)[%d] !allowed_clients\n",__FILE__, __LINE__);
+ 		return 1;
+ 	}
+ 	if (client_sa.sa.sa_family == AF_INET) {
+@@ -1386,6 +1418,7 @@ static int fcgi_is_allowed(void) {
+ 	}
+ #endif
+ 
++	FCGIDEBUG("(%s)[%d] fcgi_is_allowed return 0\n",__FILE__, __LINE__);
+ 	return 0;
+ }
+ 
+@@ -1403,6 +1436,7 @@ int fcgi_accept_request(fcgi_request *req)
+ 					return -1;
+ 				}
+ 
++				FCGIDEBUG("(%s)[%d] before req->hook.on_accept\n",__FILE__, __LINE__);
+ 				req->hook.on_accept();
+ #ifdef _WIN32
+ 				if (!req->tcp) {
+@@ -1435,9 +1469,12 @@ int fcgi_accept_request(fcgi_request *req)
+ 					socklen_t len = sizeof(sa);
+ 
+ 					FCGI_LOCK(req->listen_socket);
++					FCGIDEBUG("(%s)[%d] before accept(%d, %p, %u)\n",__FILE__, __LINE__, listen_socket, (struct sockaddr *)&sa, &len);
+ 					req->fd = accept(listen_socket, (struct sockaddr *)&sa, &len);
+ 					FCGI_UNLOCK(req->listen_socket);
+ 
++					FCGIDEBUG("(%s)[%d] accepted fd=%d\n",__FILE__, __LINE__, req->fd);
++
+ 					client_sa = sa;
+ 					if (req->fd >= 0 && !fcgi_is_allowed()) {
+ 						fcgi_log(FCGI_ERROR, "Connection disallowed: IP address '%s' has been dropped.", fcgi_get_last_client_ip());
+@@ -1449,6 +1486,7 @@ int fcgi_accept_request(fcgi_request *req)
+ 					}
+ 				}
+ 
++				FCGIDEBUG("(%s)[%d] before shutdown check\n",__FILE__, __LINE__);
+ #ifdef _WIN32
+ 				if (req->fd < 0 && (in_shutdown || errno != EINTR)) {
+ #else
+@@ -1462,6 +1500,7 @@ int fcgi_accept_request(fcgi_request *req)
+ #else
+ 				if (req->fd >= 0) {
+ #if defined(HAVE_POLL)
++					FCGIDEBUG("(%s)[%d] HAVE_POLL\n",__FILE__, __LINE__);
+ 					struct pollfd fds;
+ 					int ret;
+ 
+@@ -1470,13 +1509,18 @@ int fcgi_accept_request(fcgi_request *req)
+ 					fds.revents = 0;
+ 					do {
+ 						errno = 0;
++						FCGIDEBUG("(%s)[%d] before poll for fd=%d \n",__FILE__, __LINE__, req->fd);
+ 						ret = poll(&fds, 1, 5000);
++						FCGIDEBUG("(%s)[%d] poll returned %d, fds.revents=%d\n",__FILE__, __LINE__, ret, fds.revents);
+ 					} while (ret < 0 && errno == EINTR);
+ 					if (ret > 0 && (fds.revents & POLLIN)) {
++						FCGIDEBUG("(%s)[%d] before break\n",__FILE__, __LINE__);
+ 						break;
+ 					}
++					FCGIDEBUG("(%s)[%d] before fcgi_close\n",__FILE__, __LINE__);
+ 					fcgi_close(req, 1, 0);
+ #else
++					FCGIDEBUG("(%s)[%d] ! HAVE_POLL\n",__FILE__, __LINE__);
+ 					if (req->fd < FD_SETSIZE) {
+ 						struct timeval tv = {5,0};
+ 						fd_set set;
+@@ -1503,7 +1547,9 @@ int fcgi_accept_request(fcgi_request *req)
+ 		} else if (in_shutdown) {
+ 			return -1;
+ 		}
++		FCGIDEBUG("(%s)[%d] before hook.on_read\n",__FILE__, __LINE__);
+ 		req->hook.on_read();
++		FCGIDEBUG("(%s)[%d] before fcgi_read_request\n",__FILE__, __LINE__);
+ 		if (fcgi_read_request(req)) {
+ #ifdef _WIN32
+ 			if (is_impersonate && !req->tcp) {
+-- 
+2.38.1
+

--- a/php/php-8.2.0/patches/0013-chore-Fixes-logs-getnameinfo-in-wasi-sock-sdk.patch
+++ b/php/php-8.2.0/patches/0013-chore-Fixes-logs-getnameinfo-in-wasi-sock-sdk.patch
@@ -1,0 +1,132 @@
+From 1f8448de929007f2ee404ceb2dd9b9fe9dc9d32f Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Wed, 5 Apr 2023 11:47:39 +0300
+Subject: [PATCH 13/15] chore: Fixes, logs, getnameinfo in wasi sock sdk
+
+
+ 100.0% wasmedge_stubs/
+diff --git a/wasmedge_stubs/netdb.h b/wasmedge_stubs/netdb.h
+index c1136150..9faf3ced 100644
+--- a/wasmedge_stubs/netdb.h
++++ b/wasmedge_stubs/netdb.h
+@@ -1,6 +1,8 @@
+ #pragma once
+ // Based on https://github.com/hangedfish/wasmedge_wasi_socket_c
+ 
++#include <netinet/in.h>
++
+ struct addrinfo {
+ 	int ai_flags;
+ 	int ai_family;
+@@ -51,6 +53,12 @@ struct addrinfo {
+ #define NI_MAXHOST 255
+ #define NI_MAXSERV 32
+ 
++
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
+ struct servent {
+ 	char *s_name;
+ 	char **s_aliases;
+@@ -58,15 +66,20 @@ struct servent {
+ 	char *s_proto;
+ };
+ 
+-#ifdef __cplusplus
+-extern "C" {
+-#endif
++struct hostent {
++	char *h_name;
++	char **h_aliases;
++	int h_addrtype;
++	int h_length;
++	char **h_addr_list;
++};
++#define h_addr h_addr_list[0]
+ 
+ struct servent *getservbyname (const char *, const char *);
+ 
+ int getaddrinfo (const char *__restrict, const char *__restrict, const struct addrinfo *__restrict, struct addrinfo **__restrict);
+ void freeaddrinfo (struct addrinfo *);
+-// int getnameinfo (const struct sockaddr *__restrict, socklen_t, char *__restrict, socklen_t, char *__restrict, socklen_t, int);
++int getnameinfo (const struct sockaddr *__restrict addr, socklen_t addrlen, char *__restrict host, socklen_t hostlen, char *__restrict serv, socklen_t servlen, int flags);
+ 
+ #ifdef __cplusplus
+ }
+diff --git a/wasmedge_stubs/wasi_socket_ext.c b/wasmedge_stubs/wasi_socket_ext.c
+index 5a2a3d26..acbebba8 100644
+--- a/wasmedge_stubs/wasi_socket_ext.c
++++ b/wasmedge_stubs/wasi_socket_ext.c
+@@ -180,7 +180,7 @@ int32_t __imported_wasmedge_wasi_snapshot_preview1_sock_setsockopt(
+     uint32_t fd, int32_t level, int32_t name, int32_t *flag,
+     uint32_t *flag_size)
+     __attribute__((__import_module__("wasi_snapshot_preview1"),
+-                   __import_name__("sock_getsockopt")));
++                   __import_name__("sock_setsockopt")));
+ 
+ int socket(int domain, int type, int protocol)
+ {
+@@ -208,7 +208,7 @@ int bind(int fd, const struct sockaddr *addr, socklen_t len)
+ 
+   wasi_address_t wasi_addr;
+   memset(&wasi_addr, 0, sizeof(wasi_address_t));
+-  uint32_t port;
++  uint32_t port = 0;
+   if (AF_INET == addr->sa_family) {
+     struct sockaddr_in *sin = (struct sockaddr_in *)addr;
+     wasi_addr.buf = (uint8_t *)&sin->sin_addr;
+@@ -219,6 +219,9 @@ int bind(int fd, const struct sockaddr *addr, socklen_t len)
+     wasi_addr.buf = (uint8_t *)&sin->sin6_addr;
+     wasi_addr.size = 16;
+     port = sin->sin6_port;
++  } else {
++    errno = EAFNOSUPPORT;
++    return -1;
+   }
+ 
+   WSEDEBUG("WWSock| bind[%d]: __imported_wasmedge_wasi_snapshot_preview1_sock_bind\n", __LINE__);
+@@ -235,7 +238,7 @@ int bind(int fd, const struct sockaddr *addr, socklen_t len)
+ 
+ int connect(int fd, const struct sockaddr *addr, socklen_t len) {
+   WSEDEBUG("WWSock| connect[%d]: fd=%d, addr=%d, port=%d \n", __LINE__,
+-          fd, ((struct sockaddr_in *)addr)->sin_addr.s_addr, ((struct sockaddr_in *)addr)->sin_port);
++           fd, ((struct sockaddr_in *)addr)->sin_addr.s_addr, ((struct sockaddr_in *)addr)->sin_port);
+   wasi_address_t wasi_addr;
+   memset(&wasi_addr, 0, sizeof(wasi_address_t));
+   uint32_t port;
+@@ -249,11 +252,15 @@ int connect(int fd, const struct sockaddr *addr, socklen_t len) {
+     wasi_addr.buf = (uint8_t *)&sin->sin6_addr;
+     wasi_addr.size = 16;
+     port = ntohs(sin->sin6_port);
++  } else {
++    errno = EAFNOSUPPORT;
++    return -1;
+   }
+   int res = __imported_wasmedge_wasi_snapshot_preview1_sock_connect(
+       fd, &wasi_addr, port);
+   if (res != 0) {
+     errno = res;
++    WSEDEBUG("WWSock| connect[%d]: fd=%d failed: wasi_error=%d, errno=%d \n", __LINE__, fd, res, errno);
+     return -1;
+   }
+   return res;
+@@ -407,4 +414,11 @@ int getaddrinfo(const char *restrict host, const char *restrict serv,
+ void freeaddrinfo(struct addrinfo *p) {
+   WSEDEBUG("WWSock| freeaddrinfo[%d]: \n", __LINE__);
+   free(p);
+-}
+\ No newline at end of file
++}
++
++int getnameinfo(const struct sockaddr *__restrict addr, socklen_t addrlen, char *__restrict host, socklen_t hostlen, char *__restrict serv, socklen_t servlen, int flags)
++{
++  WSEDEBUG("WWSock| getnameinfo[%d]: \n", __LINE__);
++  // When lookup fails, software should use the IP address string as hostname
++  return EAI_FAIL;
++}
+-- 
+2.38.1
+

--- a/php/php-8.2.0/patches/0014-fix-implicit-function-declaration-in-syslog.patch
+++ b/php/php-8.2.0/patches/0014-fix-implicit-function-declaration-in-syslog.patch
@@ -1,0 +1,27 @@
+From c681c872176a665656fa8d982bc17a66edbf09b4 Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Wed, 5 Apr 2023 11:55:31 +0300
+Subject: [PATCH 14/15] fix: implicit-function-declaration in syslog
+
+
+ 100.0% main/
+diff --git a/main/php_syslog.c b/main/php_syslog.c
+index 68c7aac7..a1d6a23c 100644
+--- a/main/php_syslog.c
++++ b/main/php_syslog.c
+@@ -32,6 +32,12 @@
+ #define syslog std_syslog
+ #endif
+ 
++#ifdef __wasi__
++#define syslog(...)
++#define openlog(...)
++#define closelog()
++#endif
++
+ PHPAPI void php_syslog_str(int priority, const zend_string* message)
+ {
+ 	smart_string sbuf = {0};
+-- 
+2.38.1
+

--- a/php/php-8.2.0/patches/0015-feat-Enable-mysqlnd-and-more-network-functions-with-.patch
+++ b/php/php-8.2.0/patches/0015-feat-Enable-mysqlnd-and-more-network-functions-with-.patch
@@ -1,0 +1,244 @@
+From 1432917558030c3e4fad250168e3107b9236850d Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Wed, 5 Apr 2023 12:11:28 +0300
+Subject: [PATCH 15/15] feat: Enable mysqlnd and more network functions with
+ WasmEdge
+
+
+   8.6% ext/mysqlnd/
+  27.8% ext/standard/
+   6.5% main/streams/
+  56.9% main/
+diff --git a/ext/mysqlnd/mysqlnd_vio.c b/ext/mysqlnd/mysqlnd_vio.c
+index 65f6e54d..619f6d9e 100644
+--- a/ext/mysqlnd/mysqlnd_vio.c
++++ b/ext/mysqlnd/mysqlnd_vio.c
+@@ -23,7 +23,10 @@
+ #include "mysqlnd_ext_plugin.h"
+ #include "php_network.h"
+ 
+-#ifndef PHP_WIN32
++#ifdef WASM_RUNTIME_WASMEDGE
++#include "wasmedge_stubs/netdb.h"
++#include "wasmedge_stubs/wasi_socket_ext.h"
++#elif !defined(PHP_WIN32)
+ #include <netinet/tcp.h>
+ #else
+ #include <winsock.h>
+diff --git a/ext/standard/dns.c b/ext/standard/dns.c
+index 104f847a..79ea4f63 100644
+--- a/ext/standard/dns.c
++++ b/ext/standard/dns.c
+@@ -34,9 +34,11 @@
+ #ifdef HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+-#ifndef WASM_WASI
++#ifndef __wasi__
+ #include <netdb.h>
+-#endif // WASM_WASI
++#elif defined(WASM_RUNTIME_WASMEDGE)
++#include <wasmedge_stubs/netdb.h>
++#endif // __wasi__
+ #ifdef _OSD_POSIX
+ #undef STATUS
+ #undef T_UNSPEC
+@@ -174,7 +176,7 @@ PHP_FUNCTION(gethostbyaddr)
+ /* {{{ php_gethostbyaddr */
+ static zend_string *php_gethostbyaddr(char *ip)
+ {
+-#ifndef WASM_WASI
++#if !defined(__wasi__) || defined(WASM_RUNTIME_WASMEDGE)
+ #if defined(HAVE_IPV6) && defined(HAVE_INET_PTON)
+ 	struct sockaddr_in sa4;
+ 	struct sockaddr_in6 sa6;
+@@ -218,7 +220,7 @@ static zend_string *php_gethostbyaddr(char *ip)
+ #endif
+ #else
+ 	return NULL;
+-#endif // WASM_WASI
++#endif // __wasi__
+ }
+ /* }}} */
+ 
+@@ -245,7 +247,7 @@ PHP_FUNCTION(gethostbyname)
+ /* {{{ Return a list of IP addresses that a given hostname resolves to. */
+ PHP_FUNCTION(gethostbynamel)
+ {
+-#ifndef WASM_WASI
++#if !defined(__wasi__) || defined(WASM_RUNTIME_WASMEDGE)
+ 	char *hostname;
+ 	size_t hostname_len;
+ 	struct hostent *hp;
+@@ -289,14 +291,14 @@ PHP_FUNCTION(gethostbynamel)
+ 	}
+ #else
+ 	RETURN_FALSE;
+-#endif // WASM_WASI
++#endif // __wasi__
+ }
+ /* }}} */
+ 
+ /* {{{ php_gethostbyname */
+ static zend_string *php_gethostbyname(char *name)
+ {
+-#ifndef WASM_WASI
++#if !defined(__wasi__) || defined(WASM_RUNTIME_WASMEDGE)
+ 	struct hostent *hp;
+ 	struct in_addr *h_addr_0; /* Don't call this h_addr, it's a macro! */
+ 	struct in_addr in;
+@@ -326,7 +328,7 @@ static zend_string *php_gethostbyname(char *name)
+ 	return zend_string_init(address, strlen(address), 0);
+ #else
+ 	return NULL;
+-#endif // WASM_WASI
++#endif // __wasi__
+ }
+ /* }}} */
+ 
+diff --git a/main/network.c b/main/network.c
+index 683e11d0..bb39f27e 100644
+--- a/main/network.c
++++ b/main/network.c
+@@ -54,9 +54,12 @@
+ 
+ #ifndef PHP_WIN32
+ #include <netinet/in.h>
+-#ifndef WASM_WASI
++#if !defined(__wasi__)
+ #include <netdb.h>
+-#endif // WASM_WASI
++#elif defined(WASM_RUNTIME_WASMEDGE)
++#include <wasmedge_stubs/netdb.h>
++#include <wasmedge_stubs/wasi_socket_ext.h>
++#endif // __wasi__
+ #if HAVE_ARPA_INET_H
+ #include <arpa/inet.h>
+ #endif
+@@ -155,7 +158,9 @@ PHPAPI void php_network_freeaddresses(struct sockaddr **sal)
+  */
+ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct sockaddr ***sal, zend_string **error_string)
+ {
+-#ifndef WASM_WASI
++#if defined(__wasi__) && !defined(WASM_RUNTIME_WASMEDGE)
++	return 0;
++#else
+ 	struct sockaddr **sap;
+ 	int n;
+ #if HAVE_GETADDRINFO
+@@ -278,9 +283,8 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
+ 
+ 	*sap = NULL;
+ 	return n;
+-#else
+-	return 0;
+-#endif // WASM_WASI
++#endif // !__wasi__
++
+ }
+ /* }}} */
+ 
+@@ -316,14 +320,21 @@ PHPAPI int php_network_connect_socket(php_socket_t sockfd,
+ 		zend_string **error_string,
+ 		int *error_code)
+ {
+-#ifndef WASM_WASI
++#if defined(__wasi__) && !defined(WASM_RUNTIME_WASMEDGE)
++	return 0;
++#else
+ 	php_non_blocking_flags_t orig_flags;
+ 	int n;
+ 	int error = 0;
+ 	socklen_t len;
+ 	int ret = 0;
+ 
++#if !defined(WASM_RUNTIME_WASMEDGE)
++	// This always sets the O_NONBLOCK flag to the fd, even if asynchronous == false.
++	// connect will return EINPROGRESS, but we don't expect that when asynchronous == false
++	// Not sure how this works on Linux, but fails 1/1 on WasmEdge
+ 	SET_SOCKET_BLOCKING_MODE(sockfd, orig_flags);
++#endif
+ 
+ 	if ((n = connect(sockfd, addr, addrlen)) != 0) {
+ 		error = php_socket_errno();
+@@ -394,6 +405,7 @@ PHPAPI int php_network_connect_socket(php_socket_t sockfd,
+ 		}
+ 	}
+ 	return ret;
++#endif
+ }
+ /* }}} */
+ 
+@@ -410,9 +422,6 @@ static inline void sub_times(struct timeval a, struct timeval b, struct timeval
+ 		result->tv_sec++;
+ 		result->tv_usec -= 1000000L;
+ 	}
+-#else
+-	return 0;
+-#endif // WASM_WASI
+ }
+ /* }}} */
+ 
+@@ -457,11 +466,11 @@ php_socket_t php_network_bind_socket_to_local_addr(const char *host, unsigned po
+ 		}
+ 
+ 		/* create a socket for this address */
+-#ifndef WASM_WASI
++#if !defined(__wasi__) || defined(WASM_RUNTIME_WASMEDGE)
+ 		sock = socket(sa->sa_family, socktype, 0);
+ #else
+ 		sock = SOCK_ERR;
+-#endif // WASM_WASI
++#endif // __wasi__
+ 
+ 		if (sock == SOCK_ERR) {
+ 			continue;
+@@ -504,11 +513,11 @@ php_socket_t php_network_bind_socket_to_local_addr(const char *host, unsigned po
+ 		}
+ #endif
+ 
+-#ifndef WASM_WASI
++#if !defined(__wasi__) || defined(WASM_RUNTIME_WASMEDGE)
+ 		n = bind(sock, sa, socklen);
+ #else
+ 		n = SOCK_CONN_ERR;
+-#endif // WASM_WASI
++#endif // __wasi__
+ 
+ 		if (n != SOCK_CONN_ERR) {
+ 			goto bound;
+@@ -1376,7 +1385,7 @@ struct hostent * gethostname_re (const char *host,struct hostent *hostbuf,char *
+ #endif
+ 
+ PHPAPI struct hostent*	php_network_gethostbyname(const char *name) {
+-#ifndef WASM_WASI
++#ifndef __wasi__
+ #if !defined(HAVE_GETHOSTBYNAME_R)
+ 	return gethostbyname(name);
+ #else
+@@ -1393,5 +1402,5 @@ PHPAPI struct hostent*	php_network_gethostbyname(const char *name) {
+ #endif
+ #else
+ 	return NULL;
+-#endif // WASM_WASI
++#endif // __wasi__
+ }
+diff --git a/main/streams/xp_socket.c b/main/streams/xp_socket.c
+index b9d9f077..ecbced4b 100644
+--- a/main/streams/xp_socket.c
++++ b/main/streams/xp_socket.c
+@@ -219,9 +219,9 @@ static int php_sockop_close(php_stream *stream, int close_handle)
+ 				n = php_pollfd_for_ms(sock->socket, POLLOUT, 500);
+ 			} while (n == -1 && php_socket_errno() == EINTR);
+ #endif
+-#ifndef WASM_WASI
++#if !defined(__wasi__) || defined(WASM_RUNTIME_WASMEDGE)
+ 			closesocket(sock->socket);
+-#endif // WASM_WASI
++#endif // __wasi__
+ 			sock->socket = SOCK_ERR;
+ 		}
+ 
+-- 
+2.38.1
+

--- a/php/php-8.2.0/wlr-build.sh
+++ b/php/php-8.2.0/wlr-build.sh
@@ -16,8 +16,10 @@ export LDFLAGS_WASI="--sysroot=${WASI_SYSROOT} -lwasi-emulated-getpid -lwasi-emu
 ########## Setup the flags for php #############
 export CFLAGS_PHP='-D_POSIX_SOURCE=1 -D_GNU_SOURCE=1 -DHAVE_FORK=0 -DPNG_USER_CONFIG -DWASM_WASI'
 
+export LDFLAGS_WARNINGS='-Wno-unused-command-line-argument -Werror=implicit-function-declaration'
+
 # We need to add LDFLAGS ot CFLAGS because autoconf compiles(+links) to binary when checking stuff
-export LDFLAGS="${LDFLAGS_WASI} ${LDFLAGS_DEPENDENCIES}"
+export LDFLAGS="${LDFLAGS_WASI} ${LDFLAGS_DEPENDENCIES} ${LDFLAGS_WARNINGS}"
 export CFLAGS="${CFLAGS_CONFIG} ${CFLAGS_WASI} ${CFLAGS_DEPENDENCIES} ${CFLAGS_PHP} ${LDFLAGS}"
 
 logStatus "CFLAGS="${CFLAGS}
@@ -36,6 +38,7 @@ if [[ -z "$WLR_SKIP_CONFIGURE" ]]; then
 
     if [[ "${WLR_BUILD_FLAVOR}" == *"wasmedge"* ]]
     then
+        export PHP_CONFIGURE="${PHP_CONFIGURE} --enable-mysqlnd --with-pdo-mysql"
         export PHP_CONFIGURE="--with-wasm-runtime=wasmedge ${PHP_CONFIGURE}"
     fi
 


### PR DESCRIPTION
 - fastcgi works as part of the `php-cgi` binary, which starts a server when called with `-b hostname:port`
 - client side sockets and mysql PDO support is reusing most of the previous work done by @ereslibre 
 - there is an end to end basic example with a mysql container in `php/examples/mysql`