### PR TITLE
fix: Patch for `is_readable()` and `is_writable()` to bypass WASI preview1 limitations with stating files

### DIFF
--- a/php/php-8.2.0/patches/0017-fix-is_writable-with-stat-bypass.patch
+++ b/php/php-8.2.0/patches/0017-fix-is_writable-with-stat-bypass.patch
@@ -1,0 +1,39 @@
+From d29ed6b1e87e18e437829bee97c6aa93f4999c3f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jesu=CC=81s=20Gonza=CC=81lez?= <jesusgm@vmware.com>
+Date: Wed, 12 Apr 2023 18:01:06 +0200
+Subject: [PATCH] fix: Patch for `is_readable()` and `is_writable()` to bypass
+ WASI preview1 limitations with stating files
+
+---
+ ext/standard/filestat.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/ext/standard/filestat.c b/ext/standard/filestat.c
+index 2fdb9d76..6eddeb15 100644
+--- a/ext/standard/filestat.c
++++ b/ext/standard/filestat.c
+@@ -950,12 +950,21 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
+ 		}
+ 		php_error_docref(NULL, E_NOTICE, "Unknown file type (%d)", ssb.sb.st_mode&S_IFMT);
+ 		RETURN_STRING("unknown");
++#ifndef __wasi__
+ 	case FS_IS_W:
+ 		RETURN_BOOL((ssb.sb.st_mode & wmask) != 0);
+ 	case FS_IS_R:
+ 		RETURN_BOOL((ssb.sb.st_mode&rmask)!=0);
+ 	case FS_IS_X:
+ 		RETURN_BOOL((ssb.sb.st_mode&xmask)!=0);
++#else
++	case FS_IS_W:
++		RETURN_TRUE;
++	case FS_IS_R:
++		RETURN_TRUE;
++	case FS_IS_X:
++		RETURN_TRUE;
++#endif /* __wasi__ */
+ 	case FS_IS_FILE:
+ 		RETURN_BOOL(S_ISREG(ssb.sb.st_mode));
+ 	case FS_IS_DIR:
+-- 
+2.39.1
+


### PR DESCRIPTION
In wasi-libc `stat()`, since there is no user/group concept in Wasm, `st_mode` is initialized to `000`, as well as `st_uid` and `st_gid`. This way, `is_readable()`,  `is_writable()` and `is_executable()` will return `TRUE`.

Two approaches have been discussed:

1. Patch those methods to always return TRUE. This works for many scenarios since most PHP apps will later check (ie: `fopen()`) the concrete operation returns the right value even if the `is_xxxable()` function was previously called.

1. Trial and error. To avoid the above assumption and returning fake values that might be totally wrong, a different approach is to actually try to open/write those resources and return the result.

The latter approach seems more appropriate. The only drawback is a small penalty in performance since the execution of the new checkers takes longer than simply querying the values from stat. But once PHP's cache starts hitting, performance shouldn't be affected. But given there exist corner cases that this hack can't deal with, we decided to go with the former option, which is also what Python for WASI does (just relying on wasi-libc).