### PR TITLE
fix random_bytes failing on Windows

### DIFF
--- a/php/php-8.2.0/patches/0018-fix-random_bytes-failing-on-Windows.patch
+++ b/php/php-8.2.0/patches/0018-fix-random_bytes-failing-on-Windows.patch
@@ -1,0 +1,47 @@
+From 0b6d3fa928f5c6f0b77c5c77ca771a0260f2e8a4 Mon Sep 17 00:00:00 2001
+From: "no-reply@wasmlabs.dev" <Wasm Labs Team>
+Date: Thu, 13 Apr 2023 10:21:04 +0200
+Subject: [PATCH 18/18] fix random_bytes failing on Windows
+
+
+ 100.0% ext/random/
+diff --git a/ext/random/random.c b/ext/random/random.c
+index 161eb8e6..12f431ca 100644
+--- a/ext/random/random.c
++++ b/ext/random/random.c
+@@ -510,7 +510,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
+ #else
+ 	size_t read_bytes = 0;
+ 	ssize_t n;
+-# if (defined(__linux__) && defined(SYS_getrandom)) || (defined(__FreeBSD__) && __FreeBSD_version >= 1200000) || (defined(__DragonFly__) && __DragonFly_version >= 500700) || defined(__sun)
++# if (defined(__linux__) && defined(SYS_getrandom)) || (defined(__FreeBSD__) && __FreeBSD_version >= 1200000) || (defined(__DragonFly__) && __DragonFly_version >= 500700) || defined(__sun) || defined(__wasi__)
+ 	/* Linux getrandom(2) syscall or FreeBSD/DragonFlyBSD getrandom(2) function*/
+ 	/* Keep reading until we get enough entropy */
+ 	while (read_bytes < size) {
+@@ -527,6 +527,14 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
+ 		size_t amount_to_read = size - read_bytes;
+ #  if defined(__linux__)
+ 		n = syscall(SYS_getrandom, bytes + read_bytes, amount_to_read, 0);
++# elif defined(__wasi__)
++		// getentropy always reads the amount requested on success (0)
++		// and returns -1 otherwise
++		if (getentropy(bytes + read_bytes, amount_to_read) == 0) {
++		  n = amount_to_read;
++		} else {
++		  n = -1;
++		}
+ #  else
+ 		n = getrandom(bytes + read_bytes, amount_to_read, 0);
+ #  endif
+@@ -560,7 +568,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
+ 
+ 		if (fd < 0) {
+ 			errno = 0;
+-# if HAVE_DEV_URANDOM
++# if defined(HAVE_DEV_URANDOM) && !defined(__wasi__)
+ 			fd = open("/dev/urandom", O_RDONLY);
+ # endif
+ 			if (fd < 0) {
+-- 
+2.40.0
+


### PR DESCRIPTION
We are not currently providing a way to get random bytes in __wasi__ mode so it fallbacks to read from "/dev/urandom", which works when the module is running on Unix (and has permissions) but will always fail on Windows, where it does not exist.

The patch provides a way of getting random bytes using getentropy and disables relying on "/dev/urandom" as a fallback.