### PR TITLE
fix: Asset name for PHP CLI with wasmedge

### DIFF
--- a/.github/workflows/release-php.yaml
+++ b/.github/workflows/release-php.yaml
@@ -32,7 +32,7 @@ jobs:
           - name: wasmedge-php-
             suffix: "-wasmedge"
             flavor: ""
-            build-php-cli: false
+            build-php-cli: true
             version: 8.2.0
           - name: php-
             suffix: ""
@@ -55,7 +55,7 @@ jobs:
         # supported by GitHub (https://github.com/community/community/discussions/37883)
         if: startsWith(github.event.ref, format('refs/tags/php/{0}+', matrix.version))
         run: make php/${{ matrix.name }}${{ matrix.version }}${{ matrix.flavor }}
-      - name: Rename release artifacts
+      - name: Rename CGI release artifacts
         # Only run for the PHP version specified in the git tag.
         #
         # This if could be moved to the parent `job` section when it's
@@ -64,7 +64,7 @@ jobs:
         shell: bash
         run: |
           sudo mv build-output/php/php-${{ matrix.version }}${{ matrix.flavor }}${{ matrix.suffix }}/bin/php-cgi{${{ matrix.suffix }},-${{ matrix.version }}${{ matrix.suffix }}${{ matrix.flavor }}}.wasm
-      - name: Rename release artifacts
+      - name: Rename CLI release artifacts
         # Only run for the PHP version specified in the git tag.
         #
         # This if could be moved to the parent `job` section when it's


### PR DESCRIPTION
Fixed name can be seen here - https://github.com/assambar/webassembly-language-runtimes/releases/tag/php%2F8.2.0%2B20230418-79f102d
 
From `php-wasmedge.wasm` to `php-8.2.0-wasmedge.wasm`

Note: tried doing it in a better way (similar to what we have with libs), but could not make it workeasily, so just reused the "build-php-cli" which we got from earlier WasmEdge releases. Again, this should be fixed with proper flavors and name decisions taken during the actual build.