### PR TITLE
feat: Add libs/bzip2 to WLR

### DIFF
--- a/.github/workflows/build-libs-bzip2.yaml
+++ b/.github/workflows/build-libs-bzip2.yaml
@@ -1,0 +1,26 @@
+name: Build libs-bzip2
+on:
+  push:
+    # By specifying branches explicitly, we avoid this workflow from
+    # running on tag push. We have a dedicated workflow to be ran when
+    # a tag is pushed.
+    branches:
+      - main
+    paths:
+       - ".github/**"
+       - "libs/bzip2/**"
+       - "libs/*"
+       - "scripts/**"
+       - "Makefile*"
+       - "*.sh"
+  pull_request:
+jobs:
+  build-libs-bzip2:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: 1.0.8
+    uses: ./.github/workflows/reusable-build-lib.yaml
+    with:
+      target: bzip2/v${{ matrix.version }}

--- a/.github/workflows/release-libs-bzip2.yaml
+++ b/.github/workflows/release-libs-bzip2.yaml
@@ -1,0 +1,15 @@
+# Note that for this workflow to be triggered, the tag needs to be
+# created of the form `libs/bzip2/<version>+<buildinfo>`, where <buildinfo>
+# by convention is YYYYMMDD-<short-sha> (short SHA can be calculated
+# with `git rev-parse --short HEAD`).
+name: Release libs-bzip2
+on:
+  push:
+    tags:
+      - libs/bzip2/*
+jobs:
+  release-libs-bzip2:
+    uses: ./.github/workflows/reusable-release-external-lib.yaml
+    with:
+      target-name: "bzip2"
+      trigger: ${{ github.event.ref }}

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ oci-python-3.11.1-wasmedge: python/wasmedge-v3.11.1
 		.
 
 LIBS := \
+	bzip2 \
 	icu \
 	libjpeg \
 	libpng \

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -1,6 +1,7 @@
 .PHONY: clean
 clean:
 	make -C bundle_wlr clean
+	make -C bzip2 clean
 	make -C icu clean
 	make -C libjpeg clean
 	make -C libpng clean

--- a/libs/bzip2/Makefile
+++ b/libs/bzip2/Makefile
@@ -1,0 +1,8 @@
+WASI_SDK_VERSION ?= 19.0
+
+ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT := $(ROOT_DIR)../..
+
+include $(REPO_ROOT)/Makefile.helpers
+
+$(eval $(call create_default_external_lib_targets,$(REPO_ROOT),bzip2,$(WASI_SDK_VERSION)))

--- a/libs/bzip2/README.md
+++ b/libs/bzip2/README.md
@@ -1,0 +1,5 @@
+# About
+
+This folder builds assets of the bzip2 project.
+
+The main project page is at [https://www.sourceware.org/bzip2/](https://www.sourceware.org/bzip2/).

--- a/libs/bzip2/v1.0.8/patches/0001-chore-Add-libinstall-to-Makefile.patch
+++ b/libs/bzip2/v1.0.8/patches/0001-chore-Add-libinstall-to-Makefile.patch
@@ -1,0 +1,54 @@
+From e493fcd0205797c266e10b5d50402d49f4bd97fc Mon Sep 17 00:00:00 2001
+From: Asen Alexandrov <alexandrov@vmware.com>
+Date: Mon, 24 Apr 2023 11:45:59 +0300
+Subject: [PATCH] chore: Add libinstall to Makefile
+
+
+diff --git a/Makefile b/Makefile
+index f8a1772..2889612 100644
+--- a/Makefile
++++ b/Makefile
+@@ -25,6 +25,7 @@ CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
+ 
+ # Where you want it installed when you do 'make install'
+ PREFIX=/usr/local
++LIBDIR=$(PREFIX)/lib
+ 
+ 
+ OBJS= blocksort.o  \
+@@ -69,12 +70,18 @@ test: bzip2
+ 	cmp sample3.tst sample3.ref
+ 	@cat words3
+ 
+-install: bzip2 bzip2recover
++libinstall: libbz2.a
++	if ( test ! -d $(LIBDIR) ) ; then mkdir -p $(LIBDIR) ; fi
++	if ( test ! -d $(PREFIX)/include ) ; then mkdir -p $(PREFIX)/include ; fi
++	cp -f bzlib.h $(PREFIX)/include
++	chmod a+r $(PREFIX)/include/bzlib.h
++	cp -f libbz2.a $(LIBDIR)
++	chmod a+r $(LIBDIR)/libbz2.a
++
++install: bzip2 bzip2recover libinstall
+ 	if ( test ! -d $(PREFIX)/bin ) ; then mkdir -p $(PREFIX)/bin ; fi
+-	if ( test ! -d $(PREFIX)/lib ) ; then mkdir -p $(PREFIX)/lib ; fi
+ 	if ( test ! -d $(PREFIX)/man ) ; then mkdir -p $(PREFIX)/man ; fi
+ 	if ( test ! -d $(PREFIX)/man/man1 ) ; then mkdir -p $(PREFIX)/man/man1 ; fi
+-	if ( test ! -d $(PREFIX)/include ) ; then mkdir -p $(PREFIX)/include ; fi
+ 	cp -f bzip2 $(PREFIX)/bin/bzip2
+ 	cp -f bzip2 $(PREFIX)/bin/bunzip2
+ 	cp -f bzip2 $(PREFIX)/bin/bzcat
+@@ -85,10 +92,6 @@ install: bzip2 bzip2recover
+ 	chmod a+x $(PREFIX)/bin/bzip2recover
+ 	cp -f bzip2.1 $(PREFIX)/man/man1
+ 	chmod a+r $(PREFIX)/man/man1/bzip2.1
+-	cp -f bzlib.h $(PREFIX)/include
+-	chmod a+r $(PREFIX)/include/bzlib.h
+-	cp -f libbz2.a $(PREFIX)/lib
+-	chmod a+r $(PREFIX)/lib/libbz2.a
+ 	cp -f bzgrep $(PREFIX)/bin/bzgrep
+ 	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzegrep
+ 	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzfgrep
+-- 
+2.38.1
+

--- a/libs/bzip2/v1.0.8/wlr-build.sh
+++ b/libs/bzip2/v1.0.8/wlr-build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+if [[ ! -v WLR_ENV ]]
+then
+    echo "WLR build environment is not set"
+    exit 1
+fi
+
+export CFLAGS_CONFIG="-O0"
+
+export CFLAGS_WASI="--sysroot=${WASI_SYSROOT}"
+
+export CFLAGS_BUILD='-Werror -Wno-error=format -Wno-error=deprecated-non-prototype -Wno-error=unknown-warning-option'
+
+export CFLAGS="${CFLAGS_CONFIG} ${CFLAGS_WASI} ${CFLAGS_BUILD}"
+
+cd "${WLR_SOURCE_PATH}"
+
+source ${WLR_REPO_ROOT}/scripts/build-helpers/wlr_pkg_config.sh
+
+BZIP2_MAKE_ARGS="CC=${CC} AR=${AR} RANLIB=${RANLIB} PREFIX=${WLR_OUTPUT} LIBDIR=${WLR_OUTPUT}/lib/wasm32-wasi"
+
+logStatus "Building... "
+make ${BZIP2_MAKE_ARGS} -j libbz2.a || exit 1
+
+logStatus "Preparing artifacts... "
+make ${BZIP2_MAKE_ARGS} libinstall || exit 1
+
+logStatus "Generating pkg-config file for libbz2.a"
+DESCRIPTION="libbzip2 is a library for lossless, block-sorting data compression"
+EXTRA_LINK_FLAGS="-lbz2"
+
+wlr_pkg_config_create_pc_file "bzip2" "${WLR_PACKAGE_VERSION}" "${DESCRIPTION}" "${EXTRA_LINK_FLAGS}" || exit 1
+
+wlr_package_lib
+
+logStatus "DONE. Artifacts in ${WLR_OUTPUT}"

--- a/libs/bzip2/v1.0.8/wlr-env-repo.sh
+++ b/libs/bzip2/v1.0.8/wlr-env-repo.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [[ $1 == "--unset" ]]
+then
+    unset WLR_REPO
+    unset WLR_REPO_BRANCH
+    unset WLR_ENV_NAME
+    unset WLR_PACKAGE_VERSION
+    unset WLR_PACKAGE_NAME
+    return
+fi
+
+export WLR_REPO=https://gitlab.com/bzip2/bzip2
+export WLR_REPO_BRANCH=bzip2-1.0.8
+export WLR_ENV_NAME=bzip2/v1.0.8
+export WLR_PACKAGE_VERSION=1.0.8
+export WLR_PACKAGE_NAME=bzip2

--- a/libs/bzip2/v1.0.8/wlr-tag.sh
+++ b/libs/bzip2/v1.0.8/wlr-tag.sh
@@ -1,0 +1,1 @@
+export WLR_TAG="libs/bzip2/1.0.8"

--- a/scripts/build-helpers/wlr_pkg_config.sh
+++ b/scripts/build-helpers/wlr_pkg_config.sh
@@ -26,25 +26,25 @@ function wlr_pkg_config_reset_pc_prefix {
 }
 
 function wlr_pkg_config_create_pc_file {
-    local TARGET_LIBRARY="$1"
+    local LIBRARY_NAME="$1"
     local VERSION="$2"
     local DESCRIPTION="$3"
-    local EXTRA_LINK_FLAGS="$4"
+    local LINK_FLAGS="$4"
 
-    mkdir -p ${WLR_OUTPUT}/lib/wasm32-wasi/pkg-config 2>/dev/null || exit 1
-    local TARGET_FILE=${WLR_OUTPUT}/lib/wasm32-wasi/pkg-config/${TARGET_LIBRARY}.pc
+    mkdir -p ${WLR_OUTPUT}/lib/wasm32-wasi/pkgconfig 2>/dev/null || exit 1
+    local TARGET_FILE=${WLR_OUTPUT}/lib/wasm32-wasi/pkgconfig/${LIBRARY_NAME}.pc
 
-    mkdir -p ${WLR_OUTPUT}/lib/wasm32-wasi/pkg-config 2>/dev/null
+    mkdir -p ${WLR_OUTPUT}/lib/wasm32-wasi/pkgconfig 2>/dev/null
     cat >$TARGET_FILE <<EOF
 prefix=
 exec_prefix=\${prefix}
 libdir=\${prefix}/lib/wasm32-wasi
 includedir=\${prefix}/include
 
-Name: ${TARGET_LIBRARY}
+Name: ${LIBRARY_NAME}
 Description: ${DESCRIPTION}
 Version: ${VERSION}
-Libs: -L\${libdir} ${EXTRA_LINK_FLAGS}
+Libs: -L\${libdir} ${LINK_FLAGS}
 Cflags: -I\${includedir}
 EOF
 }


### PR DESCRIPTION
This only builds the library. The accompanying binaries used signals and file ownership, which are not available on WASI.

Here is a sample release - https://github.com/assambar/webassembly-language-runtimes/releases/tag/libs%2Fbzip2%2F1.0.8%2B20230424-ffa3f41

Also, managed to build python with this and test it 

```
wasmtime --mapdir /::$(pwd) bin/python.wasm
Python 3.11.3 (tags/v3.11.3:f3909b8, Apr 24 2023, 11:57:12) [Clang 15.0.7 ] on wasi
Type "help", "copyright", "credits" or "license" for more information.
>>> import bz2

>>> dir(bz2)
['BZ2Compressor', 'BZ2Decompressor', 'BZ2File', '_MODE_CLOSED', '_MODE_READ', '_MODE_WRITE', '__all__', '__author__', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__spec__', '_builtin_open', '_compression', 'compress', 'decompress', 'io', 'open', 'os']

>>> bz2.compress(bytes('hello there', 'utf-8'))
b'BZh91AY&SY\xe0\xed\xb01\x00\x00\x02\x11\x80@\x00\x02D\x94\x00 \x001\x0c\x00\xd3G\xa2\x10Eu;\xe2\xeeH\xa7\n\x12\x1c\x1d\xb6\x06 '

>>> cc = bz2.compress(bytes('hello there', 'utf-8'))

>>> bz2.decompress(cc)
b'hello there'
```