### PR TITLE
wasi-sdk version to 20

### DIFF
--- a/Dockerfile.wasi-builder
+++ b/Dockerfile.wasi-builder
@@ -1,6 +1,9 @@
 ARG WABT_VERSION=1.0.32
-ARG WASI_SDK_VERSION=19.0
-ARG WASI_SDK_RELEASE_NAME=wasi-sdk-19
+# E.g. WASI_SDK_VERSION=20.0
+ARG WASI_SDK_VERSION
+# E.g. WASI_SDK_RELEASE_NAME=wasi-sdk-20
+ARG WASI_SDK_RELEASE_NAME
+
 # For beta releases with specific features this goes like:
 # ARG WASI_SDK_VERSION=20.0.threads
 # ARG WASI_SDK_RELEASE_NAME=wasi-sdk-20+threads

--- a/Dockerfile.wasi-builder
+++ b/Dockerfile.wasi-builder
@@ -7,7 +7,7 @@ ARG WASI_SDK_RELEASE_NAME
 # For beta releases with specific features this goes like:
 # ARG WASI_SDK_VERSION=20.0.threads
 # ARG WASI_SDK_RELEASE_NAME=wasi-sdk-20+threads
-ARG WASI_VFS_VERSION=ddbea0e2a6a1e0e8fe0373ec3d1bdccf522178ab
+ARG WASI_VFS_VERSION=v0.4.0
 
 ARG WASI_SDK_PATH=/wasi-sdk
 ARG WASI_SDK_ASSET_NAME=wasi-sdk-${WASI_SDK_VERSION}

--- a/Makefile.builders
+++ b/Makefile.builders
@@ -17,18 +17,25 @@ wasm-base:
 push-wasm-base:
 	@$(call push_container_image,$(WASM_BASE_NAME))
 
-.PHONY: wasi-builder-19-0
-WASI_BUILDER_19_NAME := ghcr.io/vmware-labs/wasmlabs/wasi-builder:19.0
-wasi-builder-19-0:
-	@echo Building $(WASI_BUILDER_19_NAME) in $(BUILDER_ROOT_DIR) ... && \
+.PHONY: wasi-builder
+WASI_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/wasi-builder:$(WASI_SDK_VERSION)
+wasi-builder:
+	@echo Building $(WASI_BUILDER_NAME) in $(BUILDER_ROOT_DIR) ... && \
 	docker build \
 		--platform linux/amd64 \
-		--build-arg WASI_SDK_RELEASE_NAME=wasi-sdk-19 \
-		--build-arg WASI_SDK_VERSION=19.0 \
+		--build-arg WASI_SDK_RELEASE_NAME=wasi-sdk-$(word 1,$(subst ., ,$(WASI_SDK_VERSION))) \
+		--build-arg WASI_SDK_VERSION=$(WASI_SDK_VERSION) \
 		-f $(BUILDER_ROOT_DIR)/Dockerfile.wasi-builder \
-		-t $(WASI_BUILDER_19_NAME) \
+		-t $(WASI_BUILDER_NAME) \
 		$(BUILDER_ROOT_DIR)
 
-.PHONY: push-wasi-builder-19-0
-push-wasi-builder-19-0:
-	@$(call push_container_image,$(WASI_BUILDER_19_NAME))
+.PHONY: update-wasi-builder
+update-wasi-builder: wasi-builder
+	@$(call push_container_image,$(WASI_BUILDER_NAME))
+
+
+.PHONY: update-all-builders
+update-all-builders: update-wasi-builder
+	make -f php/Makefile update-php-builder
+	make -f python/Makefile update-python-builder
+	make -f ruby/Makefile update-ruby-builder

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -1,3 +1,6 @@
+# Default wask-sdk version used in builds
+WASI_SDK_VERSION ?= 19.0
+
 define push_container_image
     $(eval $@_IMAGE_NAME = $(1))
     @(docker image inspect $($@_IMAGE_NAME) 1>/dev/null 2>&1 || \

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -1,5 +1,5 @@
 # Default wask-sdk version used in builds
-WASI_SDK_VERSION ?= 19.0
+WASI_SDK_VERSION ?= 20.0
 
 define push_container_image
     $(eval $@_IMAGE_NAME = $(1))

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,0 +1,15 @@
+This document is a work in progress.
+
+# Processes
+
+## Updating Wasi-Sdk version
+
+ You will need ghcr.io credentials with rights to publish to `ghcr.io/vmware-labs/wasmlabs`!
+
+ - Bump the `WASI_SDK_VERSION ?= ##.#` in [Makefile.helpers](../Makefile.helpers)
+ - Build and publish all builder images with a new tag based on `WASI_SDK_VERSION`
+    ```
+    make -f Makefile.builders update-all-builders
+    ```
+ - Release all independent libraries
+ - Bump URLs in the libraries/runtimes which depend on them, then publish them, too

--- a/libs/bundle_wlr/Makefile
+++ b/libs/bundle_wlr/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/libs/bzip2/Makefile
+++ b/libs/bzip2/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/libs/icu/Makefile
+++ b/libs/icu/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/libs/libjpeg/Makefile
+++ b/libs/libjpeg/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/libs/libuuid/Makefile
+++ b/libs/libuuid/Makefile
@@ -1,6 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-# NOTE - the default python build is failing with wasi-sdk-19
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/libs/oniguruma/Makefile
+++ b/libs/oniguruma/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/libs/sqlite/Makefile
+++ b/libs/sqlite/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/libs/wasmedge_sock/Makefile
+++ b/libs/wasmedge_sock/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/libs/zlib/Makefile
+++ b/libs/zlib/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)../..
 

--- a/php/Makefile
+++ b/php/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)..
 

--- a/php/Makefile
+++ b/php/Makefile
@@ -8,8 +8,8 @@ PHP_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/php-builder:wasi-$(WASI_SDK_VER
 php-builder:
 	@$(call make_builder_image,$(PHP_BUILDER_NAME),$(ROOT_DIR),$(WASI_SDK_VERSION))
 
-.PHONY: push-php-builder
-push-php-builder:
+.PHONY: update-php-builder
+update-php-builder: php-builder
 	@$(call push_container_image,$(PHP_BUILDER_NAME))
 
 .PHONY: php-*

--- a/php/php-8.1.11/wlr-build.sh
+++ b/php/php-8.1.11/wlr-build.sh
@@ -15,8 +15,10 @@ export LDFLAGS_WASI="--sysroot=${WASI_SYSROOT} -lwasi-emulated-getpid -lwasi-emu
 ########## Setup the flags for php #############
 export CFLAGS_PHP='-D_POSIX_SOURCE=1 -D_GNU_SOURCE=1 -DHAVE_FORK=0 -DWASM_WASI'
 
+export LDFLAGS_WARNINGS='-Wno-unused-command-line-argument -Wno-implicit-function-declaration -Wno-incompatible-function-pointer-types'
+
 # We need to add LDFLAGS ot CFLAGS because autoconf compiles(+links) to binary when checking stuff
-export LDFLAGS="${LDFLAGS_WASI} ${LDFLAGS_DEPENDENCIES}"
+export LDFLAGS="${LDFLAGS_WASI} ${LDFLAGS_DEPENDENCIES} ${LDFLAGS_WARNINGS}"
 export CFLAGS="${CFLAGS_CONFIG} ${CFLAGS_WASI} ${CFLAGS_DEPENDENCIES} ${CFLAGS_PHP} ${LDFLAGS}"
 
 cd "${WLR_SOURCE_PATH}"

--- a/php/php-8.2.0-slim/wlr-build.sh
+++ b/php/php-8.2.0-slim/wlr-build.sh
@@ -16,8 +16,10 @@ export LDFLAGS_WASI="--sysroot=${WASI_SYSROOT} -lwasi-emulated-getpid -lwasi-emu
 ########## Setup the flags for php #############
 export CFLAGS_PHP='-D_POSIX_SOURCE=1 -D_GNU_SOURCE=1 -DHAVE_FORK=0 -DWASM_WASI'
 
+export LDFLAGS_WARNINGS='-Wno-unused-command-line-argument -Werror=implicit-function-declaration -Wno-incompatible-function-pointer-types'
+
 # We need to add LDFLAGS ot CFLAGS because autoconf compiles(+links) to binary when checking stuff
-export LDFLAGS="${LDFLAGS_WASI} ${LDFLAGS_DEPENDENCIES} ${LDFLAGS_SQLITE}"
+export LDFLAGS="${LDFLAGS_WASI} ${LDFLAGS_DEPENDENCIES} ${LDFLAGS_SQLITE} ${LDFLAGS_WARNINGS}"
 export CFLAGS="${CFLAGS_CONFIG} ${CFLAGS_WASI} ${CFLAGS_DEPENDENCIES} ${CFLAGS_PHP} ${LDFLAGS}"
 
 logStatus "CFLAGS="${CFLAGS}

--- a/php/php-8.2.0/wlr-build.sh
+++ b/php/php-8.2.0/wlr-build.sh
@@ -17,7 +17,7 @@ export LDFLAGS_WASI="--sysroot=${WASI_SYSROOT} -lwasi-emulated-getpid -lwasi-emu
 ########## Setup the flags for php #############
 export CFLAGS_PHP='-D_POSIX_SOURCE=1 -D_GNU_SOURCE=1 -DHAVE_FORK=0 -DPNG_USER_CONFIG -DWASM_WASI'
 
-export LDFLAGS_WARNINGS='-Wno-unused-command-line-argument -Werror=implicit-function-declaration'
+export LDFLAGS_WARNINGS='-Wno-unused-command-line-argument -Werror=implicit-function-declaration -Wno-incompatible-function-pointer-types'
 
 # We need to add LDFLAGS ot CFLAGS because autoconf compiles(+links) to binary when checking stuff
 export LDFLAGS="${LDFLAGS_WASI} ${LDFLAGS_DEPENDENCIES} ${LDFLAGS_WARNINGS}"

--- a/python/Makefile
+++ b/python/Makefile
@@ -8,8 +8,8 @@ PYTHON_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/python-builder:wasi-$(WASI_S
 python-builder:
 	@$(call make_builder_image,$(PYTHON_BUILDER_NAME),$(ROOT_DIR),$(WASI_SDK_VERSION))
 
-.PHONY: push-python-builder
-push-python-builder:
+.PHONY: update-python-builder
+update-python-builder: python-builder
 	@$(call push_container_image,$(PYTHON_BUILDER_NAME))
 
 .PHONY: v*

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,6 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-# NOTE - the default python build is failing with wasi-sdk-19
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)..
 

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,5 +1,3 @@
-WASI_SDK_VERSION ?= 19.0
-
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(ROOT_DIR)..
 

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -8,8 +8,8 @@ RUBY_BUILDER_NAME := ghcr.io/vmware-labs/wasmlabs/ruby-builder:wasi-$(WASI_SDK_V
 ruby-builder:
 	@$(call make_builder_image,$(RUBY_BUILDER_NAME),$(ROOT_DIR),$(WASI_SDK_VERSION))
 
-.PHONY: push-ruby-builder
-push-ruby-builder:
+.PHONY: update-ruby-builder
+update-ruby-builder: ruby-builder
 	@$(call push_container_image,$(RUBY_BUILDER_NAME))
 
 .PHONY: v*


### PR DESCRIPTION
- Simplified usage of wasi-sdk-version 
- Update default wasi-sdk version used for builds.
- Added docs about this process
 
This is a first of several changes. After republishing libs with the latest wasi-sdk, I will bump dependencies and publish php/python/ruby, etc. 