### PR TITLE
feat: try to find actual target directory to place wasi deps into

### DIFF
--- a/python/tools/wlr-libpy/src/bld_cfg.rs
+++ b/python/tools/wlr-libpy/src/bld_cfg.rs
@@ -2,27 +2,34 @@ use wlr_assets::bld_cfg::LibsConfig;
 use wlr_assets::download_asset;
 
 use std::error::Error;
-use std::path::Path;
+use std::path::PathBuf;
 
 type BoxedError = Box<dyn Error>;
 
 struct LibPythonConfig {
-    wasi_deps_path: &'static str,
     wasi_sdk_sysroot_url: &'static str,
     wasi_sdk_clang_builtins_url: &'static str,
     libpython_url: &'static str,
     libpython_binary: &'static str,
 }
 
-impl LibPythonConfig {
-    pub fn get_deps_path(&self, subpath: &str) -> String {
-        format!("{0}/{1}", self.wasi_deps_path, subpath)
+fn find_deps_path() -> PathBuf {
+    if let Ok(target) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(target).join("wasm32-wasi").join("wasi-deps");
+    } else {
+        if let Ok(cwd) = std::env::current_dir() {
+            for path in cwd.ancestors() {
+                if path.join("Cargo.lock").exists() {
+                    return path.join("target").join("wasm32-wasi").join("wasi-deps");
+                }
+            }
+        }
     }
+    return PathBuf::from("target/wasm32-wasi/wasi-deps");
 }
 
 #[cfg(feature = "py311")]
 const LIBPYTHON_CONF : LibPythonConfig = LibPythonConfig {
-    wasi_deps_path: "target/wasm32-wasi/wasi-deps",
     wasi_sdk_sysroot_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz",
     wasi_sdk_clang_builtins_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz",
     libpython_url: "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.11.4%2B20230714-11be424/libpython-3.11.4-wasi-sdk-20.0.tar.gz",
@@ -31,7 +38,6 @@ const LIBPYTHON_CONF : LibPythonConfig = LibPythonConfig {
 
 #[cfg(feature = "py312")]
 const LIBPYTHON_CONF : LibPythonConfig = LibPythonConfig {
-    wasi_deps_path: "target/wasm32-wasi/wasi-deps",
     wasi_sdk_sysroot_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz",
     wasi_sdk_clang_builtins_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz",
     libpython_url: "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.12.0%2B20231211-040d5a6/libpython-3.12.0-wasi-sdk-20.0.tar.gz",
@@ -41,20 +47,45 @@ const LIBPYTHON_CONF : LibPythonConfig = LibPythonConfig {
 pub fn configure_static_libs() -> Result<LibsConfig, BoxedError> {
     let mut libs_config = LibsConfig::new();
 
-    let wasi_deps_path = Path::new(LIBPYTHON_CONF.wasi_deps_path);
+    let wasi_deps_path = find_deps_path();
 
-    download_asset(LIBPYTHON_CONF.wasi_sdk_sysroot_url, wasi_deps_path)?;
-    libs_config.add_lib_path(LIBPYTHON_CONF.get_deps_path("wasi-sysroot/lib/wasm32-wasi"));
+    download_asset(
+        LIBPYTHON_CONF.wasi_sdk_sysroot_url,
+        wasi_deps_path.as_path(),
+    )?;
+    libs_config.add_lib_path(
+        wasi_deps_path
+            .join("wasi-sysroot")
+            .join("lib")
+            .join("wasm32-wasi")
+            .to_string_lossy()
+            .to_string(),
+    );
     libs_config.add("wasi-emulated-signal");
     libs_config.add("wasi-emulated-getpid");
     libs_config.add("wasi-emulated-process-clocks");
 
-    download_asset(LIBPYTHON_CONF.wasi_sdk_clang_builtins_url, wasi_deps_path)?;
-    libs_config.add_lib_path(LIBPYTHON_CONF.get_deps_path("lib/wasi"));
+    download_asset(
+        LIBPYTHON_CONF.wasi_sdk_clang_builtins_url,
+        wasi_deps_path.as_path(),
+    )?;
+    libs_config.add_lib_path(
+        wasi_deps_path
+            .join("lib")
+            .join("wasi")
+            .to_string_lossy()
+            .to_string(),
+    );
     libs_config.add("clang_rt.builtins-wasm32");
 
-    download_asset(LIBPYTHON_CONF.libpython_url, wasi_deps_path)?;
-    libs_config.add_lib_path(LIBPYTHON_CONF.get_deps_path("lib/wasm32-wasi"));
+    download_asset(LIBPYTHON_CONF.libpython_url, wasi_deps_path.as_path())?;
+    libs_config.add_lib_path(
+        wasi_deps_path
+            .join("lib")
+            .join("wasm32-wasi")
+            .to_string_lossy()
+            .to_string(),
+    );
     libs_config.add(LIBPYTHON_CONF.libpython_binary);
 
     Ok(libs_config)


### PR DESCRIPTION
Scenario: in a workspace setup, the library extracts the wasi-deps to every crate that links against libpython, this code tries to instead find the actually used cargo target directory

The code searches for the last occurrence of `/wasm32-wasi/` in the OUT_DIR variable so this works also for setups where the user set the CARGO_TARGET_DIR environment variable

Example:

workspace/target <= I want the files to be put here
workspace/library_a/target/wasm32-wasi/wasi-deps <= these three are currently being created
workspace/library_b/target/wasm32-wasi/wasi-deps <= these three are currently being created
workspace/library_c/target/wasm32-wasi/wasi-deps <= these three are currently being created

