### PR TITLE
fix: libpython and targets for python docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,30 @@ oci-python-3.11.4-wasmedge: python/v3.11.4-wasmedge
 		-f images/python/Dockerfile \
 		build-output
 
+.PHONY: oci-python-3.12.0
+oci-python-3.12.0: python/v3.12.0
+	docker build \
+	    --platform wasi/wasm32 \
+		--build-arg NAME=python-wasm \
+		--build-arg SUMMARY="CPython built for WASI, by Wasm Labs" \
+		--build-arg ARTIFACTS_BASE_DIR=python/v3.12.0 \
+		--build-arg PYTHON_BINARY=python-3.12.0.wasm \
+		-t ghcr.io/vmware-labs/python-wasm:3.12.0 \
+		-f images/python/Dockerfile \
+		build-output
+
+.PHONY: oci-python-3.12.0-wasmedge
+oci-python-3.12.0-wasmedge: python/v3.12.0-wasmedge
+	docker build \
+	    --platform wasi/wasm32 \
+		--build-arg NAME=python-wasm \
+		--build-arg SUMMARY="CPython built for WASI+WasmEdge, by Wasm Labs" \
+		--build-arg ARTIFACTS_BASE_DIR=python/v3.12.0-wasmedge \
+		--build-arg PYTHON_BINARY=python-3.12.0.wasm \
+		-t ghcr.io/vmware-labs/python-wasm:3.12.0-wasmedge \
+		-f images/python/Dockerfile \
+		build-output
+
 LIBS := \
 	bzip2 \
 	icu \

--- a/python/v3.12.0/wlr-build.sh
+++ b/python/v3.12.0/wlr-build.sh
@@ -114,6 +114,7 @@ addlib ${WLR_DEPS_ROOT}/build-output/lib/wasm32-wasi/libsqlite3.a
 addlib ${WLR_DEPS_ROOT}/build-output/lib/wasm32-wasi/libuuid.a
 addlib Modules/expat/libexpat.a
 addlib Modules/_decimal/libmpdec/libmpdec.a
+addlib Modules/_hacl/libHacl_Hash_SHA2.a
 save
 end
 EOF


### PR DESCRIPTION
Add the static hashlib module to the bundled libpython. Without this using libpython will fail with undefined symbols.
