### PR TITLE
chore: Add libpython3.12 support in wlr-libpy

### DIFF
--- a/python/tools/wlr-libpy/Cargo.lock
+++ b/python/tools/wlr-libpy/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "wlr-libpy"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "wlr-assets",
 ]

--- a/python/tools/wlr-libpy/Cargo.toml
+++ b/python/tools/wlr-libpy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wlr-libpy"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
@@ -8,7 +8,10 @@ wlr-assets = { path = "../../../tools/wlr-assets", optional = true }
 
 [features]
 
-default = []
+py311 = []
+py312 = []
+
+default = ["py311"]
 
 build = ["dep:wlr-assets"]
 py_main = []

--- a/python/tools/wlr-libpy/README.md
+++ b/python/tools/wlr-libpy/README.md
@@ -4,6 +4,14 @@ Helper crate for linking to the pre-built libpython from Webassembly Language Ru
 
 # Features
 
+## py311 and py312
+
+These features can be combined with the `build` feature below to chose which version of the static library gets downloaded.
+
+The default is `py311` so if you want to use CPython 3.11, you don't need to specify a thing.
+
+Otherwise you should use something like `default-features=false, features=["build", "py312"]` in your Cargo.toml
+
 ## build
 
 This feature is intended for usage in `build.rs` scripts. It will download all needed pre-built static libraries for `wasm32-wasi` and configure the linker to use them.
@@ -30,7 +38,8 @@ Here is a list of the pre-built `wasm32-wasi` static libraries:
 
  - [wasi-sysroot-20.0.tar.gz](https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz) provides some POSIX emulations
  - [libclang_rt.builtins-wasm32-wasi-20.0.tar.gz](https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz) provides some built-ins which may be required by code built via clang (like the `libpython` that we publish)
- - [libpython-3.11.4-wasi-sdk-20.0.tar](https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.11.4%2B20230714-11be424/libpython-3.11.4-wasi-sdk-20.0.tar.gz) provides our pre-built version of `libpython`
+ - [libpython-3.11.4-wasi-sdk-20.0.tar](https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.11.4%2B20230714-11be424/libpython-3.11.4-wasi-sdk-20.0.tar.gz) provides our pre-built version of `libpython3.11` (default feature)
+ - [libpython-3.12.0-wasi-sdk-20.0.tar](https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.12.0%2B20231211-040d5a6/libpython-3.12.0-wasi-sdk-20.0.tar.gz) provides our pre-built version of `libpython3.12` (`default-features=false, features=["py312"]`)
 
 ## py_main
 

--- a/python/tools/wlr-libpy/src/bld_cfg.rs
+++ b/python/tools/wlr-libpy/src/bld_cfg.rs
@@ -6,30 +6,56 @@ use std::path::Path;
 
 type BoxedError = Box<dyn Error>;
 
-const WASI_DEPS_PATH: &str = "target/wasm32-wasi/wasi-deps";
+struct LibPythonConfig {
+    wasi_deps_path: &'static str,
+    wasi_sdk_sysroot_url: &'static str,
+    wasi_sdk_clang_builtins_url: &'static str,
+    libpython_url: &'static str,
+    libpython_binary: &'static str,
+}
 
-const WASI_SDK_SYSROOT_URL: &str = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz";
-const WASI_SDK_CLANG_BUILTINS_URL: &str = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz";
-const LIBPYTHON_URL: &str = "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.11.4%2B20230714-11be424/libpython-3.11.4-wasi-sdk-20.0.tar.gz";
+impl LibPythonConfig {
+    pub fn get_deps_path(&self, subpath: &str) -> String {
+        format!("{0}/{1}", self.wasi_deps_path, subpath)
+    }
+}
+
+#[cfg(feature = "py311")]
+const LIBPYTHON_CONF : LibPythonConfig = LibPythonConfig {
+    wasi_deps_path: "target/wasm32-wasi/wasi-deps",
+    wasi_sdk_sysroot_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz",
+    wasi_sdk_clang_builtins_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz",
+    libpython_url: "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.11.4%2B20230714-11be424/libpython-3.11.4-wasi-sdk-20.0.tar.gz",
+    libpython_binary: "python3.11"
+};
+
+#[cfg(feature = "py312")]
+const LIBPYTHON_CONF : LibPythonConfig = LibPythonConfig {
+    wasi_deps_path: "target/wasm32-wasi/wasi-deps",
+    wasi_sdk_sysroot_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz",
+    wasi_sdk_clang_builtins_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz",
+    libpython_url: "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.12.0%2B20231211-040d5a6/libpython-3.12.0-wasi-sdk-20.0.tar.gz",
+    libpython_binary: "python3.12"
+};
 
 pub fn configure_static_libs() -> Result<LibsConfig, BoxedError> {
     let mut libs_config = LibsConfig::new();
 
-    let wasi_deps_path = Path::new(WASI_DEPS_PATH);
+    let wasi_deps_path = Path::new(LIBPYTHON_CONF.wasi_deps_path);
 
-    download_asset(WASI_SDK_SYSROOT_URL, wasi_deps_path)?;
-    libs_config.add_lib_path(format!("{WASI_DEPS_PATH}/wasi-sysroot/lib/wasm32-wasi"));
+    download_asset(LIBPYTHON_CONF.wasi_sdk_sysroot_url, wasi_deps_path)?;
+    libs_config.add_lib_path(LIBPYTHON_CONF.get_deps_path("wasi-sysroot/lib/wasm32-wasi"));
     libs_config.add("wasi-emulated-signal");
     libs_config.add("wasi-emulated-getpid");
     libs_config.add("wasi-emulated-process-clocks");
 
-    download_asset(WASI_SDK_CLANG_BUILTINS_URL, wasi_deps_path)?;
-    libs_config.add_lib_path(format!("{WASI_DEPS_PATH}/lib/wasi"));
+    download_asset(LIBPYTHON_CONF.wasi_sdk_clang_builtins_url, wasi_deps_path)?;
+    libs_config.add_lib_path(LIBPYTHON_CONF.get_deps_path("lib/wasi"));
     libs_config.add("clang_rt.builtins-wasm32");
 
-    download_asset(LIBPYTHON_URL, wasi_deps_path)?;
-    libs_config.add_lib_path(format!("{WASI_DEPS_PATH}/lib/wasm32-wasi"));
-    libs_config.add("python3.11");
+    download_asset(LIBPYTHON_CONF.libpython_url, wasi_deps_path)?;
+    libs_config.add_lib_path(LIBPYTHON_CONF.get_deps_path("lib/wasm32-wasi"));
+    libs_config.add(LIBPYTHON_CONF.libpython_binary);
 
     Ok(libs_config)
 }


### PR DESCRIPTION
This is waiting for `https://github.com/PyO3/pyo3/issues/3645` before I can update the respective example in [`python/examples/embedding/wasi-py-rs-pyo3`](https://github.com/vmware-labs/webassembly-language-runtimes/tree/main/python/examples/embedding/wasi-py-rs-pyo3).

I tested it with a locally modified pyo3 (that has the abi3-py312 feature) and it works as expected.