### PR TITLE
Find target directory in workspaces

### DIFF
--- a/python/tools/wlr-libpy/Cargo.lock
+++ b/python/tools/wlr-libpy/Cargo.lock
@@ -171,6 +171,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +980,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1158,7 @@ dependencies = [
 name = "wlr-libpy"
 version = "0.2.0"
 dependencies = [
+ "fslock",
  "wlr-assets",
 ]
 

--- a/python/tools/wlr-libpy/Cargo.toml
+++ b/python/tools/wlr-libpy/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
+fslock = "0.2.1"
 wlr-assets = { path = "../../../tools/wlr-assets", optional = true }
 
 [features]

--- a/python/tools/wlr-libpy/src/bld_cfg.rs
+++ b/python/tools/wlr-libpy/src/bld_cfg.rs
@@ -48,6 +48,9 @@ pub fn configure_static_libs() -> Result<LibsConfig, BoxedError> {
     let mut libs_config = LibsConfig::new();
 
     let wasi_deps_path = find_deps_path();
+    std::fs::create_dir_all(&wasi_deps_path)?;
+    let mut lock = fslock::LockFile::open(&wasi_deps_path.join(".lock"))?;
+    lock.lock()?;
 
     download_asset(
         LIBPYTHON_CONF.wasi_sdk_sysroot_url,

--- a/python/tools/wlr-libpy/src/bld_cfg.rs
+++ b/python/tools/wlr-libpy/src/bld_cfg.rs
@@ -2,27 +2,34 @@ use wlr_assets::bld_cfg::LibsConfig;
 use wlr_assets::download_asset;
 
 use std::error::Error;
-use std::path::Path;
+use std::path::PathBuf;
 
 type BoxedError = Box<dyn Error>;
 
 struct LibPythonConfig {
-    wasi_deps_path: &'static str,
     wasi_sdk_sysroot_url: &'static str,
     wasi_sdk_clang_builtins_url: &'static str,
     libpython_url: &'static str,
     libpython_binary: &'static str,
 }
 
-impl LibPythonConfig {
-    pub fn get_deps_path(&self, subpath: &str) -> String {
-        format!("{0}/{1}", self.wasi_deps_path, subpath)
+fn find_deps_path() -> PathBuf {
+    if let Ok(target) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(target).join("wasm32-wasi").join("wasi-deps");
+    } else {
+        if let Ok(cwd) = std::env::current_dir() {
+            for path in cwd.ancestors() {
+                if path.join("Cargo.lock").exists() {
+                    return path.join("target").join("wasm32-wasi").join("wasi-deps");
+                }
+            }
+        }
     }
+    return PathBuf::from("target/wasm32-wasi/wasi-deps");
 }
 
 #[cfg(feature = "py311")]
 const LIBPYTHON_CONF : LibPythonConfig = LibPythonConfig {
-    wasi_deps_path: "target/wasm32-wasi/wasi-deps",
     wasi_sdk_sysroot_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz",
     wasi_sdk_clang_builtins_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz",
     libpython_url: "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.11.4%2B20230714-11be424/libpython-3.11.4-wasi-sdk-20.0.tar.gz",
@@ -31,7 +38,6 @@ const LIBPYTHON_CONF : LibPythonConfig = LibPythonConfig {
 
 #[cfg(feature = "py312")]
 const LIBPYTHON_CONF : LibPythonConfig = LibPythonConfig {
-    wasi_deps_path: "target/wasm32-wasi/wasi-deps",
     wasi_sdk_sysroot_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz",
     wasi_sdk_clang_builtins_url: "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz",
     libpython_url: "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.12.0%2B20231211-040d5a6/libpython-3.12.0-wasi-sdk-20.0.tar.gz",
@@ -41,20 +47,45 @@ const LIBPYTHON_CONF : LibPythonConfig = LibPythonConfig {
 pub fn configure_static_libs() -> Result<LibsConfig, BoxedError> {
     let mut libs_config = LibsConfig::new();
 
-    let wasi_deps_path = Path::new(LIBPYTHON_CONF.wasi_deps_path);
+    let wasi_deps_path = find_deps_path();
 
-    download_asset(LIBPYTHON_CONF.wasi_sdk_sysroot_url, wasi_deps_path)?;
-    libs_config.add_lib_path(LIBPYTHON_CONF.get_deps_path("wasi-sysroot/lib/wasm32-wasi"));
+    download_asset(
+        LIBPYTHON_CONF.wasi_sdk_sysroot_url,
+        wasi_deps_path.as_path(),
+    )?;
+    libs_config.add_lib_path(
+        wasi_deps_path
+            .join("wasi-sysroot")
+            .join("lib")
+            .join("wasm32-wasi")
+            .to_string_lossy()
+            .to_string(),
+    );
     libs_config.add("wasi-emulated-signal");
     libs_config.add("wasi-emulated-getpid");
     libs_config.add("wasi-emulated-process-clocks");
 
-    download_asset(LIBPYTHON_CONF.wasi_sdk_clang_builtins_url, wasi_deps_path)?;
-    libs_config.add_lib_path(LIBPYTHON_CONF.get_deps_path("lib/wasi"));
+    download_asset(
+        LIBPYTHON_CONF.wasi_sdk_clang_builtins_url,
+        wasi_deps_path.as_path(),
+    )?;
+    libs_config.add_lib_path(
+        wasi_deps_path
+            .join("lib")
+            .join("wasi")
+            .to_string_lossy()
+            .to_string(),
+    );
     libs_config.add("clang_rt.builtins-wasm32");
 
-    download_asset(LIBPYTHON_CONF.libpython_url, wasi_deps_path)?;
-    libs_config.add_lib_path(LIBPYTHON_CONF.get_deps_path("lib/wasm32-wasi"));
+    download_asset(LIBPYTHON_CONF.libpython_url, wasi_deps_path.as_path())?;
+    libs_config.add_lib_path(
+        wasi_deps_path
+            .join("lib")
+            .join("wasm32-wasi")
+            .to_string_lossy()
+            .to_string(),
+    );
     libs_config.add(LIBPYTHON_CONF.libpython_binary);
 
     Ok(libs_config)


### PR DESCRIPTION
finally remembered to reopen my PR :)

implements a fallback approach to try and find the correct target directory. The resolution order is

- if `CARGO_TARGET_DIR` is set, use that
- try to find `Cargo.lock` in any ancestor of the current directory, which should always work since workspace member directories should always be children of the workspace root
- if target was still not found, fall back to the previous hardcoded path so that there's no error state

Also, this adds a lockfile since tar can error if two crates both run wlr_libpy initialization in their build.rs simultaneously - this actually happens pretty reliably when initially building with an empty target directory.

The lockfile prevents that case by only allowing one build step to extract the tarballs at the same time